### PR TITLE
Consolidate blitz scoring and refactor ranking submission

### DIFF
--- a/components/GameMap.vue
+++ b/components/GameMap.vue
@@ -144,7 +144,7 @@ import {
   MICRO_COUNTRIES,
   type MapCode,
 } from '~~/data/map.gen'
-import { invertRobinson, projectRobinson } from '~~/lib/geo'
+import { invertRobinson, mainlandBox, projectRobinson } from '~~/lib/geo'
 import { prefersReducedMotion } from '~~/lib/motion'
 import { type MapTint, useGameStore } from '~~/store/game.store'
 import type { MapClickEvent } from '~~/types/events.types'
@@ -1005,7 +1005,7 @@ let zoomOutTween: gsap.core.Tween | undefined
 let revealLocked = false
 const startZoomOut = (isoCode: MapCode, durationSeconds: number) => {
   if (!wrapper.value || !svg.value) return
-  const mainland = MAP_REGIONS[isoCode]?.[0] ?? MAP_BOUNDS[isoCode]
+  const mainland = mainlandBox(MAP_REGIONS[isoCode], MAP_BOUNDS[isoCode])
   if (!mainland) return console.warn(`Zoom-out: country not on map: ${isoCode}`)
 
   // The country's full (recognisable) frame is the END; the START is a tight
@@ -1100,9 +1100,9 @@ const moveToCountry = () => {
   const { highlightCountry } = props
   if (!highlightCountry) return
 
-  // Frame the LARGEST ring, not the whole-country bbox: RU/US antimeridian
+  // Frame the mainland, not the whole-country bbox: RU/US antimeridian
   // fragments would otherwise zoom the camera out to the whole planet.
-  const mainland = MAP_REGIONS[highlightCountry]?.[0] ?? MAP_BOUNDS[highlightCountry]
+  const mainland = mainlandBox(MAP_REGIONS[highlightCountry], MAP_BOUNDS[highlightCountry])
   if (!mainland) {
     return console.warn(`Country does not exist: ${highlightCountry}`)
   }

--- a/components/view/ViewCapitalGuess.vue
+++ b/components/view/ViewCapitalGuess.vue
@@ -67,7 +67,7 @@ import GuessTicker from '~/components/feedback/GuessTicker.vue'
 import Interstitial from '~/components/feedback/Interstitial.vue'
 import { capitalGuessScore } from '~~/lib/challenges'
 import { countryName, getCountry } from '~~/lib/country'
-import { buzzFraction } from '~~/lib/scoring'
+import { buzzScore } from '~~/lib/scoring'
 import { useGroupChallenge } from '~~/lib/useGroupChallenge'
 import type { Country, ISOCountryCode } from '~~/types/geography.types'
 
@@ -121,7 +121,7 @@ const start = () => {
 const scoreFor = (active: NonNullable<typeof challenge.value>) =>
   active.maximumGuesses
     ? capitalGuessScore(attemptsUsed.value + 1, active.maximumGuesses, active.maximumPoints)
-    : Math.round(active.maximumPoints * buzzFraction(secondsLeft.value / active.durationSeconds))
+    : buzzScore(active.maximumPoints, secondsLeft.value / active.durationSeconds)
 
 const onGuess = (country: Country) => {
   const active = challenge.value

--- a/components/view/ViewFlagPalette.vue
+++ b/components/view/ViewFlagPalette.vue
@@ -53,7 +53,7 @@ import CountryGuessInput from '~/components/country/CountryGuessInput.vue'
 import GuessTicker from '~/components/feedback/GuessTicker.vue'
 import Interstitial from '~/components/feedback/Interstitial.vue'
 import { countryName } from '~~/lib/country'
-import { buzzFraction } from '~~/lib/scoring'
+import { buzzScore } from '~~/lib/scoring'
 import { useGroupChallenge } from '~~/lib/useGroupChallenge'
 import type { Country } from '~~/types/geography.types'
 
@@ -88,7 +88,7 @@ const submitRound = (correct: boolean) => {
   // Name it sooner, keep more of the pot.
   const score =
     correct && active
-      ? Math.round(active.maximumPoints * buzzFraction(secondsLeft.value / active.durationSeconds))
+      ? buzzScore(active.maximumPoints, secondsLeft.value / active.durationSeconds)
       : 0
   submitOnce(correct && active ? [active.country] : [], score)
 }

--- a/components/view/ViewSilhouette.vue
+++ b/components/view/ViewSilhouette.vue
@@ -61,7 +61,7 @@ import { BORDERS } from '~~/data/borders.gen'
 import { countryName } from '~~/lib/country'
 import { prefersReducedMotion } from '~~/lib/motion'
 import { mainlandOutline } from '~~/lib/outline'
-import { buzzFraction } from '~~/lib/scoring'
+import { buzzScore } from '~~/lib/scoring'
 import { useGroupChallenge } from '~~/lib/useGroupChallenge'
 import type { Country, ISOCountryCode } from '~~/types/geography.types'
 
@@ -183,7 +183,7 @@ const onGuess = (country: Country) => {
 
   if (country.isoCode === active.country) {
     const remainingFraction = Math.max(0, secondsLeft.value / active.durationSeconds)
-    const clientScore = Math.round(active.maximumPoints * buzzFraction(remainingFraction))
+    const clientScore = buzzScore(active.maximumPoints, remainingFraction)
     resolve(country.isoCode, clientScore)
     return
   }

--- a/components/view/ViewStatDetective.vue
+++ b/components/view/ViewStatDetective.vue
@@ -86,7 +86,7 @@ import ZoomableImage from '~/components/challenge/ZoomableImage.vue'
 import { BORDERS } from '~~/data/borders.gen'
 import { accessorTopicLabel, getChallengeDetails } from '~~/lib/challenges'
 import { countryName } from '~~/lib/country'
-import { buzzFraction } from '~~/lib/scoring'
+import { buzzScore } from '~~/lib/scoring'
 import { useGroupChallenge } from '~~/lib/useGroupChallenge'
 import { formatNumber } from '~~/lib/number'
 import { getValueByAccessorID } from '~~/lib/values'
@@ -219,7 +219,7 @@ const onGuess = (country: Country) => {
       0,
       (active.clues.length - revealedCount.value) / active.clues.length
     )
-    const clientScore = Math.round(active.maximumPoints * buzzFraction(remainingFraction))
+    const clientScore = buzzScore(active.maximumPoints, remainingFraction)
     resolve(country.isoCode, clientScore)
     return
   }

--- a/lib/challenges.ts
+++ b/lib/challenges.ts
@@ -41,7 +41,7 @@ import type {
 import type * as gameTypes from '~~/types/game.types'
 import { isValidISOCode, type Amount, type ISOCountryCode } from '~~/types/geography.types'
 import { shuffleArray } from './arrays'
-import { haversineKm, type LatLng } from './geo'
+import { haversineKm, mainlandBox, type LatLng } from './geo'
 import { attemptDecayScore, attemptFraction } from './scoring'
 import { isRouteComplete, pickTraversal } from './traversal'
 import { getValueByAccessorID } from './values'
@@ -456,7 +456,7 @@ const getWaterBlitzChallenge = async (
   kinds: WaterFeatureKind[]
 ): Promise<WaterBlitzChallenge | undefined> => {
   const candidates = (await waterFeaturePool(game, kinds)).filter(
-    feature => feature.countries.length >= (kinds.includes('river') ? 3 : 3)
+    feature => feature.countries.length >= 3
   )
   const feature = candidates[Math.floor(Math.random() * candidates.length)]
   if (!feature) return undefined
@@ -645,45 +645,6 @@ const getFlagPaletteChallenge = (game: gameTypes.Game): FlagPaletteChallenge | u
   }
 }
 
-/** Mother-tongue scoring: same blitz shape as water — found ratio, wrong bites. */
-export const scoreMotherTongue = ({
-  challenge,
-  submittedGuesses,
-}: {
-  challenge: MotherTongueChallenge
-  submittedGuesses: ISOCountryCode[]
-}): { scored: number; maximum: number } => {
-  const answers = new Set(challenge.countries)
-  const unique = [...new Set(submittedGuesses)]
-  const correct = unique.filter(isoCode => answers.has(isoCode)).length
-  const wrong = unique.length - correct
-  const scored = Math.max(
-    0,
-    Math.round((challenge.maximumPoints * correct) / challenge.countries.length) - wrong
-  )
-  return { scored, maximum: challenge.maximumPoints }
-}
-
-/** Blitz-family scoring: found ratio scales the pot, wrong guesses bite it. */
-export const scoreWaterBlitz = ({
-  challenge,
-  submittedGuesses,
-}: {
-  challenge: WaterBlitzChallenge
-  submittedGuesses: ISOCountryCode[]
-}): { scored: number; maximum: number } => {
-  const answers = new Set(challenge.countries)
-  const unique = [...new Set(submittedGuesses)]
-  const correct = unique.filter(isoCode => answers.has(isoCode)).length
-  const wrong = unique.length - correct
-
-  const scored = Math.max(
-    0,
-    Math.round((challenge.maximumPoints * correct) / challenge.countries.length) - wrong
-  )
-  return { scored, maximum: challenge.maximumPoints }
-}
-
 /**
  * Recognition modes deal from the generated disputed-territories dataset.
  * Dynamic import for the same reason as the water dealer: only nitro runs
@@ -773,19 +734,6 @@ const boxDistance = (
   b: readonly [number, number, number, number]
 ) => Math.hypot(a[0] + a[2] / 2 - (b[0] + b[2] / 2), a[1] + a[3] / 2 - (b[1] + b[3] / 2))
 
-/**
- * A country's mainland: its largest ring. The whole-country bbox is useless for
- * distance — the US box spans the Pacific to reach Guam, putting its centre
- * closer to Russia than to Canada.
- */
-const mainlandBox = (
-  rings: readonly (readonly [number, number, number, number])[] | undefined,
-  fallback: readonly [number, number, number, number]
-) =>
-  rings?.length
-    ? rings.reduce((largest, ring) => (ring[2] * ring[3] > largest[2] * largest[3] ? ring : largest))
-    : fallback
-
 /** Beyond this projected distance a guess is worth nothing. Tuned so a
  *  neighbouring country still scores well and another continent scores zero. */
 const GHOST_STATE_FALLOFF = 260
@@ -843,9 +791,9 @@ export const scoreNoMansLand = ({
 
   if (truth.size === 0 && guess.size === 0) return { scored: maximum, maximum }
 
+  // Union is never zero past the both-empty case above.
   const intersection = [...guess].filter(isoCode => truth.has(isoCode)).length
   const union = new Set([...guess, ...truth]).size
-  if (union === 0) return { scored: 0, maximum }
   return { scored: Math.max(0, Math.round(maximum * (intersection / union))), maximum }
 }
 
@@ -969,24 +917,6 @@ export const scoreTraversalSubmission = ({
   const minimumGuesses = Math.max(0, challenge.optimalHops - 1)
   const wastedGuesses = submittedGuesses.length - minimumGuesses
   return { scored: attemptDecayScore(wastedGuesses, maximum), maximum }
-}
-
-/** Blitz: points scale with neighbours found; wrong names each cost one. */
-export const scoreNeighbourBlitz = ({
-  challenge,
-  submittedGuesses,
-}: {
-  challenge: NeighbourBlitzChallenge
-  submittedGuesses: ISOCountryCode[]
-}): { scored: number; maximum: number } => {
-  const maximum = challenge.maximumPoints
-  const neighbourSet = new Set(challenge.neighbours)
-  const unique = [...new Set(submittedGuesses)]
-  const correct = unique.filter(isoCode => neighbourSet.has(isoCode)).length
-  const wrong = unique.length - correct
-
-  const raw = Math.round(maximum * (correct / challenge.neighbours.length)) - wrong
-  return { scored: Math.max(0, Math.min(raw, maximum)), maximum }
 }
 
 /**
@@ -2276,41 +2206,39 @@ export const getCorrectRanking = ({
   return sorted.map(value => value.isoCode)
 }
 
+/**
+ * Score a ranking round: full marks per country in its exact slot, one point
+ * less per slot of displacement in either direction, nothing beyond that.
+ *
+ * Server-authoritative: only the player's dealt hand counts, each country
+ * once — a padded or foreign submission can't inflate the score (which feeds
+ * board movement 1:1) or the pot.
+ */
 export const scoreChallengeSubmission = ({
   groupChallengeAccessorId,
   submittedRanking,
+  dealtCountries,
 }: {
   groupChallengeAccessorId: GroupChallengeAccessorId
   submittedRanking: ISOCountryCode[]
+  dealtCountries: ISOCountryCode[]
 }): {
   scored: number
   maximum: number
 } => {
+  const dealt = new Set(dealtCountries)
+  const submitted = [...new Set(submittedRanking)].filter(isoCode => dealt.has(isoCode))
+  const correctRanking = getCorrectRanking({ groupChallengeAccessorId, isoCodes: dealtCountries })
+
   let accruedPoints = 0
-  const correctRanking = getCorrectRanking({ groupChallengeAccessorId, isoCodes: submittedRanking })
   for (const [index, isoCode] of correctRanking.entries()) {
-    for (let offset = 0; offset < MAXIMUM_SCORE_PER_COUNTRY; offset++) {
-      const points = MAXIMUM_SCORE_PER_COUNTRY - offset
-      const earlier = submittedRanking[index - offset]
-      if (earlier === isoCode) {
-        accruedPoints += points
-        break
-      }
-
-      if (index === 0) {
-        continue
-      }
-
-      const later = submittedRanking[index + offset]
-      if (later === isoCode) {
-        accruedPoints += points
-        break
-      }
-    }
+    const submittedIndex = submitted.indexOf(isoCode)
+    if (submittedIndex === -1) continue
+    accruedPoints += Math.max(0, MAXIMUM_SCORE_PER_COUNTRY - Math.abs(submittedIndex - index))
   }
 
   return {
     scored: accruedPoints,
-    maximum: submittedRanking.length * MAXIMUM_SCORE_PER_COUNTRY,
+    maximum: dealtCountries.length * MAXIMUM_SCORE_PER_COUNTRY,
   }
 }

--- a/lib/events/server/submit-final-challenge-answer.handler.ts
+++ b/lib/events/server/submit-final-challenge-answer.handler.ts
@@ -110,8 +110,6 @@ export const submitFinalChallengeAnswerHandler = defineGameHandler(
         break
     }
 
-    console.log({ currentChallenge, correct })
-
     // Wrong answer knocks the player out of the gauntlet. The result pause
     // runs OUTSIDE the per-game queue — holding the lock for five seconds
     // would stall every other player — and the follow-up re-enters through

--- a/lib/events/server/submit-group-challenge-answers.handler.ts
+++ b/lib/events/server/submit-group-challenge-answers.handler.ts
@@ -5,14 +5,12 @@ import {
   scoreChallengeSubmission,
   scoreGhostState,
   scoreHotCold,
-  scoreMotherTongue,
-  scoreNeighbourBlitz,
   scoreNoMansLand,
   scorePinLandmark,
   scoreTraversalSubmission,
-  scoreWaterBlitz,
 } from '~~/lib/challenges'
 import { getFinalChallenges } from '~~/lib/challenges/final-challenge'
+import { blitzScore } from '~~/lib/scoring'
 import {
   individualChallengeAccessors,
   isValidIndividualChallengeAccessorId,
@@ -57,10 +55,11 @@ export const submitGroupChallengeAnswersHandler = defineGameHandler(
           throw new TypeError('kind mismatch')
         }
         answer = { submitted: eventData.ranking, correct: roundChallenge.neighbours }
-        scoring = scoreNeighbourBlitz({
-          challenge: roundChallenge,
-          submittedGuesses: eventData.ranking,
-        })
+        scoring = blitzScore(
+          roundChallenge.neighbours,
+          eventData.ranking,
+          roundChallenge.maximumPoints
+        )
         break
       }
       case 'hot-cold': {
@@ -102,19 +101,21 @@ export const submitGroupChallengeAnswersHandler = defineGameHandler(
       case 'highlands': {
         if (roundChallenge._type !== 'water-blitz-challenge') throw new TypeError('kind mismatch')
         answer = { submitted: eventData.ranking, correct: roundChallenge.countries }
-        scoring = scoreWaterBlitz({
-          challenge: roundChallenge,
-          submittedGuesses: eventData.ranking,
-        })
+        scoring = blitzScore(
+          roundChallenge.countries,
+          eventData.ranking,
+          roundChallenge.maximumPoints
+        )
         break
       }
       case 'mother-tongue': {
         if (roundChallenge._type !== 'mother-tongue-challenge') throw new TypeError('kind mismatch')
         answer = { submitted: eventData.ranking, correct: roundChallenge.countries }
-        scoring = scoreMotherTongue({
-          challenge: roundChallenge,
-          submittedGuesses: eventData.ranking,
-        })
+        scoring = blitzScore(
+          roundChallenge.countries,
+          eventData.ranking,
+          roundChallenge.maximumPoints
+        )
         break
       }
       case 'flag-palette': {
@@ -205,6 +206,7 @@ export const submitGroupChallengeAnswersHandler = defineGameHandler(
         scoring = scoreChallengeSubmission({
           groupChallengeAccessorId: roundChallenge.id,
           submittedRanking: eventData.ranking,
+          dealtCountries: originalRanking,
         })
       }
     }
@@ -221,7 +223,6 @@ export const submitGroupChallengeAnswersHandler = defineGameHandler(
       player.moves = [
         {
           endTile: finalTile,
-          steps: 2,
           challenge: getFinalChallenges({ game }),
         },
       ]
@@ -232,15 +233,16 @@ export const submitGroupChallengeAnswersHandler = defineGameHandler(
 
     game.rounds[length - 1].playerTurns[playerId] = { points: scoring }
 
-    // Take current position + scoring, split on each challenge
+    // The scored points ARE the tiles to walk: the slice starts one past the
+    // tile the player stands on and runs `scored` tiles forward. Split into
+    // one move per challenge gate along the way.
     const potentialProgress = player.currentPosition + scoring.scored
-    const potentialTiles = [...game.tiles.slice(player.currentPosition, potentialProgress)]
+    const potentialTiles = game.tiles.slice(player.currentPosition + 1, potentialProgress + 1)
 
-    // Here, we add player moves. Each of these will be executed sequentially and players
-    // will move an according amount of steps
+    // Each move is executed sequentially; challenge moves stop one tile
+    // before their gate (see enterMovementPhaseHandler).
     const moves: PlayerMove[] = []
     while (potentialTiles.length) {
-      console.log(`Moveset: ${moves.length + 1}`)
       // Identify any special tiles in the moveset
       const specialTileIndex = potentialTiles.findIndex(tile =>
         [...individualChallengeAccessors, 'final'].includes(tile.type)
@@ -249,30 +251,21 @@ export const submitGroupChallengeAnswersHandler = defineGameHandler(
 
       const spliceCount = specialTileIndex === -1 ? potentialTiles.length : specialTileIndex
       const moveset = potentialTiles.splice(0, spliceCount + 1)
-      console.log({ spliceCount, moveset, potentialTiles })
       let move: PlayerMove = {
         endTile: moveset[moveset.length - 1],
-        steps: moveset.length,
       }
 
       switch (true) {
         // If player has reached final challenge
         case moveset.some(tile => tile.type === 'final'):
-          console.log('> Final challenge', { specialTile, specialTileIndex })
-
           move = {
             endTile: specialTile,
-            steps: moveset.length, // Stop one tile before
             challenge: getFinalChallenges({ game }),
           }
           break
         // If we have an individual challenge in our moveset
         case isValidIndividualChallengeAccessorId(specialTile?.type):
           {
-            console.log('> Individual challenge', {
-              specialTile,
-              specialTileIndex,
-            })
             const { type: accessorId } = specialTile
             if (!isValidIndividualChallengeAccessorId(accessorId)) {
               throw new EvalError(`Invalid accessor id for challenge: ${accessorId}`)
@@ -280,7 +273,6 @@ export const submitGroupChallengeAnswersHandler = defineGameHandler(
 
             move = {
               endTile: specialTile,
-              steps: specialTileIndex,
               challenge: getIndividualChallenge({
                 accessorId,
                 difficulty: game.difficulty,

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -58,6 +58,23 @@ const COMPASS_POINTS = [
 export const compassLabel = (bearing: number): string =>
   COMPASS_POINTS[Math.round(bearing / 45) % 8]
 
+// --- Projected map-space boxes -------------------------------------------------
+
+/** An axis-aligned box in the map's projected SVG space: [x, y, width, height]. */
+export type MapBox = [number, number, number, number]
+
+/**
+ * A country's mainland box. The whole-country bbox lies for RU/US-class
+ * countries — antimeridian fragments stretch it across the map, putting the
+ * US centre closer to Russia than to Canada. MAP_REGIONS emits per-ring boxes
+ * sorted largest-first, so the mainland is ring 0; `fallback` (usually
+ * MAP_BOUNDS) covers countries with no ring data.
+ */
+export const mainlandBox = <T extends MapBox | undefined>(
+  rings: MapBox[] | undefined,
+  fallback: T
+): MapBox | T => rings?.[0] ?? fallback
+
 // --- Robinson projection ------------------------------------------------------
 //
 // data/map.gen.ts stores SVG paths already projected through d3's geoRobinson

--- a/lib/scoring.test.ts
+++ b/lib/scoring.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import {
   capitalGuessScore,
+  getCorrectRanking,
+  scoreChallengeSubmission,
   scoreGhostState,
   scoreHotCold,
   scoreTraversalSubmission,
 } from './challenges'
-import { attemptFraction, buzzFraction } from './scoring'
+import { attemptFraction, blitzScore, buzzFraction } from './scoring'
 import type { GhostStateChallenge, HotColdChallenge } from '~~/types/challenges/group-modes.type'
 import type { TraversalChallenge } from '~~/types/challenges/traversal-challenge.type'
 import type { ISOCountryCode } from '~~/types/geography.types'
@@ -56,7 +58,17 @@ describe('scoreHotCold', () => {
 
   it('floors a found-but-wasteful attempt at two points', () => {
     const submittedGuesses: ISOCountryCode[] = [
-      'BR', 'CL', 'AR', 'CO', 'EC', 'BO', 'UY', 'VE', 'PY', 'GY', 'PE',
+      'BR',
+      'CL',
+      'AR',
+      'CO',
+      'EC',
+      'BO',
+      'UY',
+      'VE',
+      'PY',
+      'GY',
+      'PE',
     ]
     expect(scoreHotCold({ challenge: hotCold(21), submittedGuesses })).toEqual({
       scored: 2,
@@ -86,7 +98,18 @@ describe('scoreTraversalSubmission', () => {
 
   it('floors a completed-but-wasteful route at two points', () => {
     const submittedGuesses: ISOCountryCode[] = [
-      'BE', 'NL', 'LU', 'CH', 'AT', 'IT', 'SI', 'HR', 'HU', 'SK', 'CZ', 'DE',
+      'BE',
+      'NL',
+      'LU',
+      'CH',
+      'AT',
+      'IT',
+      'SI',
+      'HR',
+      'HU',
+      'SK',
+      'CZ',
+      'DE',
     ]
     expect(scoreTraversalSubmission({ challenge: traversal(21), submittedGuesses })).toEqual({
       scored: 2,
@@ -162,6 +185,60 @@ describe('capitalGuessScore', () => {
     for (const maximum of [12, 15, 21]) {
       expect(capitalGuessScore(2, 2, maximum)).toBeLessThan(capitalGuessScore(1, 2, maximum))
     }
+  })
+})
+
+describe('scoreChallengeSubmission', () => {
+  const groupChallengeAccessorId = 'geography.area.total'
+  const dealtCountries: ISOCountryCode[] = ['RU', 'US', 'FR', 'PT', 'LU']
+  // RU > US > FR > PT > LU by total area — derived, not hardcoded, so a data
+  // regeneration can't silently invalidate the expectations below.
+  const correct = getCorrectRanking({ groupChallengeAccessorId, isoCodes: dealtCountries })
+
+  const score = (submittedRanking: ISOCountryCode[]) =>
+    scoreChallengeSubmission({ groupChallengeAccessorId, submittedRanking, dealtCountries })
+
+  it('pays full marks for the exact ranking', () => {
+    expect(score(correct)).toEqual({ scored: 15, maximum: 15 })
+  })
+
+  it('credits the top-ranked country when placed a slot late', () => {
+    // Swapping #1 and #2 leaves both one slot off (2 points each); the
+    // asymmetric scorer this replaces paid the displaced #1 nothing.
+    const swapped = [correct[1], correct[0], ...correct.slice(2)]
+    expect(score(swapped)).toEqual({ scored: 13, maximum: 15 })
+  })
+
+  it('scores displacement symmetrically in both directions', () => {
+    // Reversal displaces the ends by 4, the next pair by 2, centre exact.
+    expect(score([...correct].reverse())).toEqual({ scored: 5, maximum: 15 })
+  })
+
+  it('ignores countries that were never dealt', () => {
+    // A padded submission must not inflate the score (it feeds movement 1:1)
+    const padded: ISOCountryCode[] = ['DE', 'BR', ...correct, 'CN', 'IN']
+    expect(score(padded)).toEqual({ scored: 15, maximum: 15 })
+  })
+
+  it('counts a duplicated country once and keeps the dealt maximum', () => {
+    expect(score([correct[0], correct[0], correct[0]])).toEqual({ scored: 3, maximum: 15 })
+  })
+})
+
+describe('blitzScore', () => {
+  const answers: ISOCountryCode[] = ['FR', 'DE', 'PL', 'CZ', 'AT']
+
+  it('scales the pot by the found ratio', () => {
+    expect(blitzScore(answers, ['FR', 'DE'], 15)).toEqual({ scored: 6, maximum: 15 })
+    expect(blitzScore(answers, [...answers], 15)).toEqual({ scored: 15, maximum: 15 })
+  })
+
+  it('bites one point per wrong guess and counts duplicates once', () => {
+    expect(blitzScore(answers, ['FR', 'DE', 'ES', 'ES'], 15)).toEqual({ scored: 5, maximum: 15 })
+  })
+
+  it('never pays below zero', () => {
+    expect(blitzScore(answers, ['ES', 'PT', 'IT', 'GB'], 15)).toEqual({ scored: 0, maximum: 15 })
   })
 })
 

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -10,6 +10,29 @@ export const BUZZ_FLOOR = 0.35
 export const buzzFraction = (remainingFraction: number): number =>
   BUZZ_FLOOR + (1 - BUZZ_FLOOR) * Math.max(0, Math.min(1, remainingFraction))
 
+/** Points for buzzing in with `remainingFraction` of the clock left. */
+export const buzzScore = (maximumPoints: number, remainingFraction: number): number =>
+  Math.round(maximumPoints * buzzFraction(remainingFraction))
+
+/**
+ * Blitz-family scoring (water modes, mother-tongue, neighbour-blitz): the
+ * found ratio scales the pot, every wrong guess bites one point. Duplicate
+ * guesses count once.
+ */
+export const blitzScore = (
+  answers: readonly string[],
+  submittedGuesses: readonly string[],
+  maximumPoints: number
+): { scored: number; maximum: number } => {
+  const answerSet = new Set(answers)
+  const unique = [...new Set(submittedGuesses)]
+  const correct = unique.filter(guess => answerSet.has(guess)).length
+  const wrong = unique.length - correct
+
+  const raw = answerSet.size ? Math.round((maximumPoints * correct) / answerSet.size) - wrong : 0
+  return { scored: Math.max(0, Math.min(raw, maximumPoints)), maximum: maximumPoints }
+}
+
 /** A found answer worth `maximum`, docked per wasted attempt, never below `floor`. */
 export const attemptDecayScore = (wasted: number, maximum: number, step = 2, floor = 2): number =>
   Math.max(floor, maximum - Math.max(0, wasted) * step)

--- a/pages/test.vue
+++ b/pages/test.vue
@@ -53,7 +53,6 @@ const mockGame = reactive<Game>({
 mockGame.players['mock-player-1'].moves = [
   {
     endTile: tiles[5],
-    steps: 2,
     challenge: { _type: 'individual-challenge', id: 'flag', country: 'FR' },
   },
 ]

--- a/types/game.types.ts
+++ b/types/game.types.ts
@@ -31,20 +31,8 @@ export interface Game {
 export const gameDifficulties = ['easy', 'normal', 'hard'] as const
 export type GameDifficulty = (typeof gameDifficulties)[number]
 
-export interface PlayerPosition {
-  currentPosition: number
-  moves: PlayerMove[]
-  progress: PlayerProgress[]
-}
-
-export interface PlayerProgress {
-  round: number
-  endTilePosition: number
-}
-
 export interface PlayerMove {
   endTile: Tile
-  steps: number
   challenge?: IndividualChallenge | FinalChallenge
 }
 


### PR DESCRIPTION
Centralizes duplicated blitz-family scoring logic and improves ranking challenge validation by tracking dealt countries server-side.

**Key changes:**

- Extract `blitzScore()` to `lib/scoring.ts` as the single source for water-blitz, mother-tongue, and neighbour-blitz scoring (replaces three identical implementations)
- Add `buzzScore()` helper to `lib/scoring.ts` for consistent buzz-in point calculation
- Refactor `scoreChallengeSubmission()` to accept `dealtCountries` parameter, filtering submissions to only count countries from the dealt hand (prevents padding/foreign submissions from inflating scores or pot)
- Simplify ranking score calculation: direct index lookup instead of offset-based search, symmetric displacement scoring in both directions
- Move `mainlandBox()` utility from `lib/challenges.ts` to `lib/geo.ts` (geographic concern, not challenge-specific)
- Remove `PlayerProgress` interface and `steps` field from `PlayerMove` (movement distance derived from scored points, not stored)
- Clean up console.log statements and redundant comments in movement phase handler
- Update all call sites to use centralized `blitzScore()` and new `buzzScore()` signatures
- Add comprehensive test coverage for ranking submission with edge cases (padding, duplicates, displacement)

The changes enforce server-authoritative scoring by validating submissions against the dealt hand, preventing client-side manipulation of board movement.

https://claude.ai/code/session_01LTmn1VGaAhTp4UQMh84S4S