### PR TITLE
Improve country search with fuzzy matching and local names

### DIFF
--- a/components/country/CountryGuessInput.vue
+++ b/components/country/CountryGuessInput.vue
@@ -4,35 +4,51 @@
       ref="input"
       v-model="query"
       type="text"
+      role="combobox"
       :placeholder="placeholder"
       autocomplete="off"
+      aria-autocomplete="list"
+      :aria-expanded="suggestions.length > 0"
+      :aria-controls="listId"
+      :aria-activedescendant="highlighted ? optionId(highlighted) : undefined"
       :disabled="disabled"
-      @keydown.down.prevent="
-        highlightedIndex = Math.min(highlightedIndex + 1, suggestions.length - 1)
-      "
-      @keydown.up.prevent="highlightedIndex = Math.max(highlightedIndex - 1, 0)"
+      @keydown.down.prevent="moveHighlight(1)"
+      @keydown.up.prevent="moveHighlight(-1)"
+      @keydown.esc="query = ''"
     />
-    <ul v-if="suggestions.length" class="suggestions">
+    <ul v-if="suggestions.length" :id="listId" ref="list" class="suggestions" role="listbox">
       <li
         v-for="(suggestion, index) in suggestions"
+        :id="optionId(suggestion)"
         :key="suggestion.isoCode"
+        role="option"
+        :aria-selected="index === highlightedIndex"
         :class="{ highlighted: index === highlightedIndex }"
         @mousedown.prevent="pick(suggestion)"
       >
         <CountryFlag class="suggestion-flag" :country="suggestion" mode="background" />
-        <span>{{ countryName(suggestion) }}</span>
+        <span class="suggestion-name">{{ countryName(suggestion) }}</span>
+        <span v-if="localCountryName(suggestion)" class="suggestion-local">
+          {{ localCountryName(suggestion) }}
+        </span>
       </li>
     </ul>
   </form>
 </template>
 <script lang="ts" setup>
-import { countryName, findCountryByName, searchCountriesByName } from '~~/lib/country'
+import {
+  countryName,
+  findCountryByName,
+  localCountryName,
+  searchCountriesByName,
+} from '~~/lib/country'
 import type { Country, ISOCountryCode } from '~~/types/geography.types'
 import CountryFlag from './CountryFlag.vue'
 
 /**
- * The typed country guess box: live suggestions, forgiving name matching
- * (case, diacritics, aliases), keyboard and pointer selection.
+ * The typed country guess box: live suggestions with local-language names,
+ * forgiving name matching (case, diacritics, aliases, typos), keyboard and
+ * pointer selection.
  */
 const props = defineProps({
   placeholder: {
@@ -53,18 +69,43 @@ const props = defineProps({
 const emit = defineEmits<{ guess: [country: Country]; miss: [input: string] }>()
 
 const query = ref('')
-const highlightedIndex = ref(0)
 const input = ref<HTMLInputElement>()
+const list = ref<HTMLUListElement>()
+
+const listId = useId()
+const optionId = (country: Country) => `${listId}-${country.isoCode}`
 
 const suggestions = computed(() => {
   if (props.disabled) return []
-  const taken = new Set(props.excluded)
-  return searchCountriesByName(query.value, 8)
-    .filter(country => !taken.has(country.isoCode))
-    .slice(0, 6)
+  return searchCountriesByName(query.value, 6, new Set(props.excluded))
 })
 
-watch(suggestions, () => (highlightedIndex.value = 0))
+/**
+ * The highlight is anchored to a country, not a slot: when the list shifts
+ * under the cursor (an `excluded` update lands, results reorder), the
+ * selection stays on the same country instead of silently becoming another.
+ * Typing clears the anchor, so the highlight returns to the best match.
+ */
+const chosenIso = ref<ISOCountryCode>()
+watch(query, () => (chosenIso.value = undefined))
+
+const highlightedIndex = computed(() => {
+  const index = suggestions.value.findIndex(country => country.isoCode === chosenIso.value)
+  return index === -1 ? 0 : index
+})
+const highlighted = computed<Country | undefined>(() => suggestions.value[highlightedIndex.value])
+
+const moveHighlight = (delta: number) => {
+  const options = suggestions.value
+  if (!options.length) return
+  const index = Math.max(0, Math.min(highlightedIndex.value + delta, options.length - 1))
+  chosenIso.value = options[index].isoCode
+}
+
+// The list scrolls once it caps out at 40vh — keep the highlight in view
+watch(highlightedIndex, index =>
+  nextTick(() => list.value?.children[index]?.scrollIntoView({ block: 'nearest' }))
+)
 
 const pick = (country: Country) => {
   query.value = ''
@@ -72,9 +113,9 @@ const pick = (country: Country) => {
 }
 
 const submitTyped = () => {
+  if (!query.value.trim()) return
   const direct = findCountryByName(query.value)
-  const highlighted = suggestions.value[highlightedIndex.value] ?? suggestions.value[0]
-  const country = direct ?? highlighted
+  const country = direct ?? highlighted.value
   if (!country) {
     emit('miss', query.value)
     return
@@ -150,5 +191,23 @@ defineExpose({ focus: () => input.value?.focus() })
   height: 1.9rem;
   flex-shrink: 0;
   border: 0.1rem solid hsla(215.7, 76.4%, 21.6%, 0.25);
+}
+
+.suggestion-name {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.suggestion-local {
+  opacity: 0.55;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 0.8em;
+  margin-left: auto;
+  text-align: right;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 </style>

--- a/components/view/ViewTraversalChallenge.vue
+++ b/components/view/ViewTraversalChallenge.vue
@@ -36,31 +36,13 @@
 
     <section class="guess-box">
       <GuessTicker :entries="entries" :players="gameStore.game?.players ?? {}" />
-      <form class="guess-form map-caption" @submit.prevent="submitTypedGuess">
-        <input
-          ref="guessInput"
-          v-model="query"
-          type="text"
-          placeholder="Type a country…"
-          autocomplete="off"
-          :disabled="submitted"
-          @keydown.down.prevent="
-            highlightedIndex = Math.min(highlightedIndex + 1, suggestions.length - 1)
-          "
-          @keydown.up.prevent="highlightedIndex = Math.max(highlightedIndex - 1, 0)"
-        />
-        <ul v-if="suggestions.length" class="suggestions">
-          <li
-            v-for="(suggestion, index) in suggestions"
-            :key="suggestion.isoCode"
-            :class="{ highlighted: index === highlightedIndex }"
-            @mousedown.prevent="submitGuess(suggestion)"
-          >
-            <CountryFlag class="suggestion-flag" :country="suggestion" mode="background" />
-            <span>{{ countryName(suggestion) }}</span>
-          </li>
-        </ul>
-      </form>
+      <CountryGuessInput
+        ref="guessInput"
+        :disabled="submitted"
+        :excluded="excluded"
+        @guess="submitGuess"
+        @miss="announce({ hint: 'No country by that name' })"
+      />
     </section>
 
     <footer>
@@ -94,9 +76,10 @@
 </template>
 <script lang="ts" setup>
 import CountryFlag from '~/components/country/CountryFlag.vue'
+import CountryGuessInput from '~/components/country/CountryGuessInput.vue'
 import GuessTicker from '~/components/feedback/GuessTicker.vue'
 import Interstitial from '~/components/feedback/Interstitial.vue'
-import { countryName, findCountryByName, getCountry, searchCountriesByName } from '~~/lib/country'
+import { countryName, getCountry } from '~~/lib/country'
 import { distancesFrom, isNeighbour, isRouteComplete } from '~~/lib/traversal'
 import { useGroupChallenge } from '~~/lib/useGroupChallenge'
 import type { MapTint } from '~~/store/game.store'
@@ -118,21 +101,17 @@ const {
 } = useGroupChallenge('traversal-challenge', { solo: false })
 
 const guesses = ref<ISOCountryCode[]>([])
-const query = ref('')
-const highlightedIndex = ref(0)
-const guessInput = ref<HTMLInputElement>()
+const guessInput = ref<InstanceType<typeof CountryGuessInput>>()
 
 const guessesLeft = computed(() => (challenge.value?.maximumClicks ?? 0) - guesses.value.length)
 
-const suggestions = computed(() => {
-  if (!challenge.value || submitted.value) return []
-  const taken = new Set([challenge.value.start, challenge.value.target, ...guesses.value])
-  return searchCountriesByName(query.value, 8)
-    .filter(country => !taken.has(country.isoCode))
-    .slice(0, 6)
-})
-
-watch(suggestions, () => (highlightedIndex.value = 0))
+// Endpoints leave the suggestions but stay typeable in full — submitGuess
+// answers an exact endpoint guess with its hint rather than spending a turn.
+const excluded = computed(() =>
+  challenge.value
+    ? [challenge.value.start, challenge.value.target, ...guesses.value]
+    : ([] as ISOCountryCode[])
+)
 
 /**
  * Guesses connected (through other guesses) to either endpoint — everything
@@ -242,7 +221,6 @@ const submitGuess = (country: Country) => {
   }
 
   guesses.value.push(country.isoCode)
-  query.value = ''
   // A wrong step is named — it cost its guesser and helps nobody. A right one
   // is a stepping stone on a route the others are still hunting, so the room
   // sees only that somebody found one.
@@ -263,15 +241,6 @@ const submitGuess = (country: Country) => {
     announce({ hint: 'Out of guesses!' })
     setTimeout(submitRound, 1200)
   }
-}
-
-const submitTypedGuess = () => {
-  const direct = findCountryByName(query.value)
-  const picked = suggestions.value[highlightedIndex.value] ?? suggestions.value[0]
-  const country = direct ?? picked
-  if (!country) return announce({ hint: 'No country by that name' })
-
-  submitGuess(country)
 }
 
 const onInterstitialDone = () => {
@@ -331,66 +300,6 @@ header {
   display: flex;
   align-items: center;
   flex-flow: column nowrap;
-}
-
-.guess-form {
-  width: 34rem;
-  max-width: 84vw;
-  position: relative;
-  pointer-events: auto;
-  padding: 0.6rem;
-
-  input {
-    width: 100%;
-    border: none;
-    outline: none;
-    background: none;
-    font-size: 2.2rem;
-    text-align: center;
-    font-family: inherit;
-    color: var(--dark-blue);
-
-    &::placeholder {
-      opacity: 0.45;
-      color: var(--dark-blue);
-    }
-  }
-}
-
-.suggestions {
-  left: 0;
-  right: 0;
-  top: 100%;
-  margin: 0.6rem 0 0;
-  padding: 0.4rem;
-  list-style: none;
-  position: absolute;
-  border-radius: 1.2rem;
-  backdrop-filter: blur(0.5rem);
-  background: hsla(36, 100%, 98%, 0.94);
-  border: 0.1rem solid hsla(215.7, 76.4%, 21.6%, 0.2);
-
-  li {
-    gap: 1rem;
-    display: flex;
-    cursor: pointer;
-    align-items: center;
-    border-radius: 0.8rem;
-    padding: 0.5rem 0.9rem;
-    color: var(--dark-blue);
-
-    &.highlighted,
-    &:hover {
-      background: hsla(197.6, 51.2%, 41.8%, 0.12);
-    }
-  }
-}
-
-.suggestion-flag {
-  width: 2.8rem;
-  height: 1.9rem;
-  flex-shrink: 0;
-  border: 0.1rem solid hsla(215.7, 76.4%, 21.6%, 0.25);
 }
 
 footer {

--- a/lib/country.test.ts
+++ b/lib/country.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { findCountryByName, localCountryName, searchCountriesByName } from './country'
+import { getCountry } from '~~/lib/country'
+
+const isoCodes = (query: string, limit?: number, excluded?: ReadonlySet<string>) =>
+  searchCountriesByName(query, limit, excluded as ReadonlySet<never>).map(
+    country => country.isoCode
+  )
+
+describe('findCountryByName', () => {
+  it('resolves names regardless of case, accents and articles', () => {
+    expect(findCountryByName('sweden')?.isoCode).toBe('SE')
+    expect(findCountryByName('CÔTE D’IVOIRE')?.isoCode).toBe('CI')
+    expect(findCountryByName('The Gambia')?.isoCode).toBe('GM')
+  })
+
+  it('accepts "Gambia" for "The Gambia" (and the other The-countries)', () => {
+    expect(findCountryByName('Gambia')?.isoCode).toBe('GM')
+    expect(findCountryByName('Bahamas')?.isoCode).toBe('BS')
+    expect(findCountryByName('Dominican Republic')?.isoCode).toBe('DO')
+  })
+
+  it('resolves common aliases', () => {
+    expect(findCountryByName('UK')?.isoCode).toBe('GB')
+    expect(findCountryByName('Ivory Coast')?.isoCode).toBe('CI')
+  })
+
+  it('resolves local-language names, including co-official variants', () => {
+    expect(findCountryByName('Deutschland')?.isoCode).toBe('DE')
+    expect(findCountryByName('Suomi')?.isoCode).toBe('FI')
+    expect(findCountryByName('Svizzera')?.isoCode).toBe('CH')
+    expect(findCountryByName('Bharat')?.isoCode).toBe('IN')
+  })
+
+  it('never matches input that normalizes to nothing', () => {
+    expect(findCountryByName('')).toBeUndefined()
+    expect(findCountryByName('!!! 123')).toBeUndefined()
+  })
+})
+
+describe('localCountryName', () => {
+  it('returns the first local variant when it differs from the English name', () => {
+    expect(localCountryName(getCountry('DE'))).toBe('Deutschland')
+    expect(localCountryName(getCountry('CH'))).toBe('Schweiz')
+  })
+
+  it('returns nothing when the local name is the English name', () => {
+    expect(localCountryName(getCountry('AU'))).toBeUndefined()
+    expect(localCountryName(getCountry('GM'))).toBeUndefined()
+  })
+})
+
+describe('searchCountriesByName', () => {
+  it('returns nothing for empty or unmatchable queries', () => {
+    expect(isoCodes('')).toEqual([])
+    expect(isoCodes('   ')).toEqual([])
+    expect(isoCodes('zzzzzzzzzzzz')).toEqual([])
+  })
+
+  it('ranks prefix matches ahead of substring matches', () => {
+    expect(isoCodes('india')[0]).toBe('IN')
+    expect(isoCodes('chin')[0]).toBe('CN')
+  })
+
+  it('ranks whole-word prefixes ahead of plain substrings', () => {
+    const guinea = isoCodes('guinea')
+    // Guinea itself first, then word-boundary hits like Papua New Guinea
+    expect(guinea[0]).toBe('GN')
+    expect(guinea).toContain('PG')
+  })
+
+  it('breaks ties toward the shorter name', () => {
+    const ind = isoCodes('ind')
+    expect(ind.indexOf('IN')).toBeLessThan(ind.indexOf('ID'))
+  })
+
+  it('finds countries through local-language variants', () => {
+    expect(isoCodes('deutsch')[0]).toBe('DE')
+    expect(isoCodes('nippon')[0]).toBe('JP')
+  })
+
+  it('forgives transpositions and missing letters without hurting exact matches', () => {
+    expect(isoCodes('Swtizerland')).toContain('CH')
+    expect(isoCodes('Sweeden')[0]).toBe('SE')
+    expect(isoCodes('Grmany')).toContain('DE')
+    expect(isoCodes('Protugal')).toContain('PT')
+    // A fuzzy hit never displaces the literal match for the same letters
+    expect(isoCodes('china')[0]).toBe('CN')
+    expect(isoCodes('iran')[0]).toBe('IR')
+  })
+
+  it('tolerates typos mid-word while the name is still being typed', () => {
+    expect(isoCodes('swtiz')).toContain('CH')
+  })
+
+  it('keeps very short queries literal', () => {
+    for (const country of searchCountriesByName('chi')) {
+      expect(countrySearchableNames(country)).toMatch(/chi/)
+    }
+  })
+
+  it('honors the excluded set without starving the list', () => {
+    const excluded = new Set(isoCodes('a', 3))
+    const results = isoCodes('a', 6, excluded)
+    expect(results).toHaveLength(6)
+    for (const isoCode of results) expect(excluded.has(isoCode)).toBe(false)
+  })
+
+  it('caps results at the limit', () => {
+    expect(isoCodes('a', 4)).toHaveLength(4)
+  })
+})
+
+/** Every haystack the search can match a country through, normalized-ish. */
+const countrySearchableNames = (country: {
+  name: { english: string; local: string }
+}): string => `${country.name.english} ${country.name.local}`.toLowerCase()

--- a/lib/country.ts
+++ b/lib/country.ts
@@ -53,6 +53,26 @@ export const normalizeCountryName = (value: string): string =>
     .trim()
     .replace(/^the /, '')
 
+/**
+ * The data's `name.local` packs co-official variants into one string
+ * ("Schweiz / Suisse / Svizzera / Svizra") — split them so each is
+ * individually typeable and searchable.
+ */
+const localNameVariants = (country: Country): string[] =>
+  country.name.local
+    .split('/')
+    .map(variant => variant.trim())
+    .filter(Boolean)
+
+/** First local-language name, when it meaningfully differs from the English one. */
+export const localCountryName = (country: Country): string | undefined => {
+  const [local] = localNameVariants(country)
+  if (!local || normalizeCountryName(local) === normalizeCountryName(country.name.english)) {
+    return undefined
+  }
+  return local
+}
+
 /** Common alternative names people actually type, mapped onto the data's ISO codes. */
 const COUNTRY_ALIASES: { [alias: string]: ISOCountryCode } = {
   usa: 'US',
@@ -90,46 +110,115 @@ let nameIndex: Map<string, ISOCountryCode> | undefined
 const getNameIndex = (): Map<string, ISOCountryCode> => {
   if (nameIndex) return nameIndex
 
-  nameIndex = new Map()
+  const index = (nameIndex = new Map())
+  const add = (name: string, isoCode: ISOCountryCode) => {
+    const normalized = normalizeCountryName(name)
+    // Names that normalize away entirely would otherwise collide on ''
+    if (normalized) index.set(normalized, isoCode)
+  }
   for (const country of Object.values(COUNTRIES)) {
-    nameIndex.set(normalizeCountryName(country.name.english), country.isoCode)
-    nameIndex.set(normalizeCountryName(country.name.local), country.isoCode)
+    add(country.name.english, country.isoCode)
+    for (const variant of localNameVariants(country)) add(variant, country.isoCode)
   }
   for (const [alias, isoCode] of Object.entries(COUNTRY_ALIASES)) {
-    nameIndex.set(alias, isoCode)
+    index.set(alias, isoCode)
   }
 
-  return nameIndex
+  return index
 }
 
 /** Resolve a typed name (any casing, accents, common aliases) to a country. */
 export const findCountryByName = (input: string): Country | undefined => {
-  const isoCode = getNameIndex().get(normalizeCountryName(input))
+  const normalized = normalizeCountryName(input)
+  if (!normalized) return undefined
+  const isoCode = getNameIndex().get(normalized)
   return isoCode ? COUNTRIES[isoCode] : undefined
 }
 
-/** Autocomplete: prefix matches first, then substring matches, deduped. */
-export const searchCountriesByName = (query: string, limit = 6): Country[] => {
+/**
+ * Damerau–Levenshtein distance (adjacent transpositions count as one edit —
+ * the typo dyslexic and fast typists actually make), capped at `max`:
+ * anything beyond returns `max + 1`.
+ */
+const editDistance = (a: string, b: string, max: number): number => {
+  if (a === b) return 0
+  if (Math.abs(a.length - b.length) > max) return max + 1
+
+  let twoAgo: number[] = []
+  let oneAgo = Array.from({ length: b.length + 1 }, (_, j) => j)
+  for (let i = 1; i <= a.length; i++) {
+    const row = [i]
+    let rowMinimum = i
+    for (let j = 1; j <= b.length; j++) {
+      let cost = Math.min(
+        oneAgo[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+        oneAgo[j] + 1,
+        row[j - 1] + 1
+      )
+      if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
+        cost = Math.min(cost, twoAgo[j - 2] + 1)
+      }
+      row.push(cost)
+      if (cost < rowMinimum) rowMinimum = cost
+    }
+    if (rowMinimum > max) return max + 1
+    twoAgo = oneAgo
+    oneAgo = row
+  }
+
+  return oneAgo[b.length]
+}
+
+/** How a candidate name matched: tier, edits spent, name length — lower wins. */
+type MatchRank = [tier: number, edits: number, length: number]
+
+const compareRank = (a: MatchRank, b: MatchRank): number =>
+  a[0] - b[0] || a[1] - b[1] || a[2] - b[2]
+
+/**
+ * Autocomplete over english names, local-name variants and aliases.
+ * Tiers: prefix, then word-prefix ("guinea" → "Papua New Guinea"), then
+ * substring, then fuzzy (typo-tolerant, edit budget scaled to query length).
+ * Fuzzy hits can never outrank a literal match, so the tolerance costs no
+ * relevancy; ties break toward shorter names ("India" before "Indonesia").
+ */
+export const searchCountriesByName = (
+  query: string,
+  limit = 6,
+  excluded?: ReadonlySet<ISOCountryCode>
+): Country[] => {
   const normalized = normalizeCountryName(query)
   if (!normalized) return []
 
-  const prefix: ISOCountryCode[] = []
-  const substring: ISOCountryCode[] = []
+  const maxEdits = normalized.length >= 7 ? 2 : normalized.length >= 4 ? 1 : 0
+
+  const best = new Map<ISOCountryCode, MatchRank>()
   for (const [name, isoCode] of getNameIndex()) {
-    if (name.startsWith(normalized)) prefix.push(isoCode)
-    else if (name.includes(normalized)) substring.push(isoCode)
+    if (excluded?.has(isoCode)) continue
+
+    let rank: MatchRank | undefined
+    if (name.startsWith(normalized)) rank = [0, 0, name.length]
+    else if (name.includes(` ${normalized}`)) rank = [1, 0, name.length]
+    else if (name.includes(normalized)) rank = [2, 0, name.length]
+    else if (maxEdits) {
+      // Compare against both the whole name (typo in a finished word) and its
+      // same-length prefix (typo while still typing)
+      const edits = Math.min(
+        editDistance(normalized, name, maxEdits),
+        editDistance(normalized, name.slice(0, normalized.length), maxEdits)
+      )
+      if (edits <= maxEdits) rank = [3, edits, name.length]
+    }
+
+    if (!rank) continue
+    const current = best.get(isoCode)
+    if (!current || compareRank(rank, current) < 0) best.set(isoCode, rank)
   }
 
-  const seen = new Set<ISOCountryCode>()
-  const results: Country[] = []
-  for (const isoCode of [...prefix, ...substring]) {
-    if (seen.has(isoCode)) continue
-    seen.add(isoCode)
-    results.push(COUNTRIES[isoCode])
-    if (results.length >= limit) break
-  }
-
-  return results
+  return [...best.entries()]
+    .sort(([, a], [, b]) => compareRank(a, b))
+    .slice(0, limit)
+    .map(([isoCode]) => COUNTRIES[isoCode])
 }
 
 export const getRandomISOCountryCode = (modifier?: 'large' | 'small'): ISOCountryCode => {


### PR DESCRIPTION
Enhances the country search experience with typo tolerance, better ranking, and display of local-language names.

**Changes:**

- **Fuzzy matching**: Added Damerau–Levenshtein edit distance algorithm to forgive transpositions and missing letters, with edit budgets scaled to query length (0 edits for queries <4 chars, 1 for 4-6, 2 for 7+)

- **Improved ranking**: Replaced simple prefix/substring matching with a four-tier system: exact prefix → word-boundary prefix → substring → fuzzy matches, with ties broken by edit count then name length

- **Local name variants**: Split co-official names (e.g., "Schweiz / Suisse / Svizzera / Svizra") into individually searchable variants via new `localNameVariants()` helper

- **New `localCountryName()` export**: Returns the first local-language name when it meaningfully differs from the English name, used for UI display

- **Enhanced `searchCountriesByName()`**: Added optional `excluded` parameter to filter results, refactored to track best match per country across all name variants

- **Refactored `CountryGuessInput.vue`**: Extracted from `ViewTraversalChallenge.vue` as a reusable component with improved accessibility (ARIA attributes), local name display in suggestions, and highlight anchoring to country identity rather than list position

- **Added comprehensive tests**: New `country.test.ts` covering exact matching, aliases, local names, fuzzy matching, and edge cases

The fuzzy matching is carefully tuned to never displace exact matches, preserving relevancy while adding typo tolerance.

https://claude.ai/code/session_01RnQdexX6kQq4SXTbebxK6A