### PR TITLE
Improve sketch scoring with smoothing and refined alignment

### DIFF
--- a/lib/outline.test.ts
+++ b/lib/outline.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import { largestRing, normalizeOutline, resampleClosed, scoreSketch } from './outline'
+import type { OutlinePoint } from './outline'
+import { MAP_PATHS } from '~~/data/map.gen'
+
+// Grading calibration tests: honest finger drawings must earn real points,
+// lazy blobs must not, and better drawings must always beat worse ones.
+
+const ring = (code: keyof typeof MAP_PATHS): OutlinePoint[] => {
+  const mainland = largestRing(MAP_PATHS[code])
+  if (!mainland) throw new ReferenceError(`No ring for ${code}`)
+  return mainland
+}
+
+const smooth = (points: OutlinePoint[], window: number): OutlinePoint[] => {
+  const half = Math.floor(window / 2)
+  const count = points.length
+  return points.map((_, index) => {
+    let sumX = 0
+    let sumY = 0
+    for (let offset = -half; offset <= half; offset++) {
+      const [x, y] = points[(index + offset + count) % count]
+      sumX += x
+      sumY += y
+    }
+    return [sumX / window, sumY / window]
+  })
+}
+
+/**
+ * A deterministic stand-in for a human drawing: heavy smoothing (fingers
+ * cannot trace coastline detail), low-frequency wobble, a slight tilt and
+ * an uneven stretch. Amplitudes are in normalized units (longer side = 1).
+ */
+const handDrawn = (
+  target: OutlinePoint[],
+  quality: { smooth: number; wobble: number; tilt: number; stretch: number }
+): OutlinePoint[] => {
+  const base = smooth(normalizeOutline(resampleClosed(target, 64)), quality.smooth)
+  const count = base.length
+  const wobbled: OutlinePoint[] = base.map(([x, y], index) => {
+    const angle = (index / count) * Math.PI * 2
+    return [
+      x + Math.cos(angle * 3 + 1) * quality.wobble,
+      y + Math.sin(angle * 2) * quality.wobble,
+    ]
+  })
+  const cos = Math.cos(quality.tilt)
+  const sin = Math.sin(quality.tilt)
+  return wobbled.map(([x, y]) => [
+    (x * cos - y * sin) * quality.stretch,
+    (x * sin + y * cos) / quality.stretch,
+  ])
+}
+
+const CAREFUL = { smooth: 5, wobble: 0.01, tilt: 0.04, stretch: 1.03 }
+const TYPICAL = { smooth: 9, wobble: 0.02, tilt: 0.07, stretch: 1.06 }
+const ROUGH = { smooth: 15, wobble: 0.035, tilt: 0.12, stretch: 1.1 }
+
+const circle = (points = 64): OutlinePoint[] =>
+  Array.from({ length: points }, (_, index) => {
+    const angle = (index / points) * Math.PI * 2
+    return [Math.cos(angle), Math.sin(angle)]
+  })
+
+describe('scoreSketch', () => {
+  it('pays full marks for a perfect tracing', () => {
+    for (const code of ['FR', 'IT', 'JP'] as const) {
+      expect(scoreSketch(ring(code), ring(code), 20)).toBe(20)
+    }
+  })
+
+  it('pays nothing for an empty drawing', () => {
+    expect(scoreSketch([], ring('FR'), 20)).toBe(0)
+  })
+
+  it('pays a careful hand drawing most of the pot', () => {
+    for (const code of ['FR', 'IT', 'BR', 'SE'] as const) {
+      const scored = scoreSketch(handDrawn(ring(code), CAREFUL), ring(code), 100)
+      expect(scored, code).toBeGreaterThanOrEqual(70)
+    }
+  })
+
+  it('pays a typical honest drawing at least half the pot', () => {
+    for (const code of ['FR', 'IT', 'BR', 'SE'] as const) {
+      const scored = scoreSketch(handDrawn(ring(code), TYPICAL), ring(code), 100)
+      expect(scored, code).toBeGreaterThanOrEqual(50)
+    }
+  })
+
+  it('still pays a rough but recognizable drawing', () => {
+    for (const code of ['FR', 'IT', 'BR', 'SE'] as const) {
+      const scored = scoreSketch(handDrawn(ring(code), ROUGH), ring(code), 100)
+      expect(scored, code).toBeGreaterThanOrEqual(25)
+    }
+  })
+
+  it('never lets a worse drawing beat a better one', () => {
+    for (const code of ['FR', 'IT', 'BR', 'SE'] as const) {
+      const careful = scoreSketch(handDrawn(ring(code), CAREFUL), ring(code), 100)
+      const typical = scoreSketch(handDrawn(ring(code), TYPICAL), ring(code), 100)
+      const rough = scoreSketch(handDrawn(ring(code), ROUGH), ring(code), 100)
+      expect(careful, code).toBeGreaterThanOrEqual(typical)
+      expect(typical, code).toBeGreaterThanOrEqual(rough)
+    }
+  })
+
+  it('pays a lazy circle almost nothing on distinctive shapes', () => {
+    for (const code of ['IT', 'NO', 'CL', 'JP'] as const) {
+      expect(scoreSketch(circle(), ring(code), 100), code).toBeLessThanOrEqual(5)
+    }
+  })
+
+  it('pays a wrong-country tracing almost nothing', () => {
+    expect(scoreSketch(ring('SE'), ring('IT'), 100)).toBeLessThanOrEqual(10)
+    // Brazil and Australia are both wide compact blobs — a sliver of credit
+    // for a genuinely confusable silhouette is fine, a real payout is not.
+    expect(scoreSketch(ring('BR'), ring('AU'), 100)).toBeLessThanOrEqual(15)
+    expect(scoreSketch(ring('EG'), ring('CL'), 100)).toBeLessThanOrEqual(10)
+  })
+})

--- a/lib/outline.ts
+++ b/lib/outline.ts
@@ -254,14 +254,35 @@ const rmsNormalize = (points: OutlinePoint[]): OutlinePoint[] => {
   return points.map(([x, y]) => [(x - centerX) / scale, (y - centerY) / scale])
 }
 
+/**
+ * Moving-average smoothing over a closed ring. Real borders carry fractal
+ * detail (fjords, deltas) no finger can trace; grading both shapes lightly
+ * smoothed measures the gross form the player could actually reproduce.
+ */
+const smoothClosed = (points: OutlinePoint[], window = 3): OutlinePoint[] => {
+  if (window <= 1 || points.length < window) return points
+  const half = Math.floor(window / 2)
+  const count = points.length
+  return points.map((_, index) => {
+    let sumX = 0
+    let sumY = 0
+    for (let offset = -half; offset <= half; offset++) {
+      const [x, y] = points[(index + offset + count) % count]
+      sumX += x
+      sumY += y
+    }
+    return [sumX / window, sumY / window]
+  })
+}
+
 /** Map a sketch's outline distance onto the round's point scale. */
 export const scoreSketch = (
   drawn: OutlinePoint[],
   target: OutlinePoint[],
   maximumPoints: number
 ): number => {
-  const a = rmsNormalize(resampleClosed(drawn))
-  const b = rmsNormalize(resampleClosed(target))
+  const a = rmsNormalize(smoothClosed(resampleClosed(drawn)))
+  const b = rmsNormalize(smoothClosed(resampleClosed(target)))
   if (!a.length || !b.length) return 0
 
   const nearestDistances = (from: OutlinePoint[], to: OutlinePoint[]) =>
@@ -277,23 +298,33 @@ export const scoreSketch = (
     const misses = [...nearestDistances(candidate, b), ...nearestDistances(b, candidate)]
     const mean = misses.reduce((sum, miss) => sum + miss, 0) / misses.length
     // Mean distance alone flatters featureless blobs — every point of an
-    // oval is "near" a compact country's border. Blending in the 90th-
-    // percentile miss demands the distinctive features actually show up.
-    const worst = [...misses].sort((x, y) => x - y)[Math.floor(misses.length * 0.9)]
-    return mean * 0.6 + worst * 0.4
+    // oval is "near" a compact country's border. Blending in the 85th-
+    // percentile miss demands the distinctive features actually show up,
+    // without letting one forgotten peninsula sink the whole drawing.
+    const worst = [...misses].sort((x, y) => x - y)[Math.floor(misses.length * 0.85)]
+    return mean * 0.7 + worst * 0.3
   }
 
-  // Small scale search: drawing size is placement, not shape — a sketch 10%
-  // too large should not bleed points. Shape mismatch survives every scale.
+  // Alignment search: a hand drawing tilts a few degrees and squashes one
+  // axis without the player meaning either — that is placement, not shape.
+  // Shape mismatch survives every rotation and stretch in this window.
   let distance = Infinity
-  for (const scale of [0.88, 0.94, 1, 1.06, 1.12]) {
-    distance = Math.min(distance, blend(a.map(([x, y]) => [x * scale, y * scale])))
+  for (const rotation of [-0.1, -0.05, 0, 0.05, 0.1]) {
+    const cos = Math.cos(rotation)
+    const sin = Math.sin(rotation)
+    const rotated: OutlinePoint[] = a.map(([x, y]) => [x * cos - y * sin, x * sin + y * cos])
+    for (const scaleX of [0.92, 1, 1.08]) {
+      for (const scaleY of [0.92, 1, 1.08]) {
+        distance = Math.min(distance, blend(rotated.map(([x, y]) => [x * scaleX, y * scaleY])))
+      }
+    }
   }
 
-  // Calibrated clusters (RMS units): honest human drawings — bulging,
-  // oversized, offset — land 0.04–0.09; the best ellipse-on-a-round-country
-  // manages 0.14; wrong-country tracings sit ≥0.18. Full marks ≤0.07,
-  // nothing from 0.16 up.
-  const band = Math.max(0, Math.min(1, 1 - (distance - 0.07) / 0.09))
-  return Math.round(maximumPoints * Math.pow(band, 1.4))
+  // Calibrated on simulated finger drawings of real outlines (RMS units):
+  // careful sketches land 0.05–0.13, typical honest ones 0.07–0.16, rough
+  // but recognizable 0.09–0.22; a bounding-box ellipse sits ≥0.18 on any
+  // country with a distinctive shape, wrong-country tracings ≥0.20. Full
+  // marks ≤0.07, nothing from 0.25 up.
+  const band = Math.max(0, Math.min(1, 1 - (distance - 0.07) / 0.18))
+  return Math.round(maximumPoints * Math.pow(band, 1.3))
 }


### PR DESCRIPTION
Refines the sketch scoring algorithm to better calibrate grading against realistic hand-drawn submissions while preventing lazy submissions from earning undeserved points.

**Key changes:**
- Add `smoothClosed()` function to apply moving-average smoothing to both drawn and target outlines, accounting for fractal detail in real borders that fingers cannot trace
- Expand alignment search from simple scaling to include rotation (±0.1 rad) and independent axis scaling, better modeling how hand drawings naturally tilt and squash
- Adjust distance blending from 60/40 to 70/30 (mean/percentile) and shift percentile from 90th to 85th, reducing penalty for isolated missed features
- Recalibrate scoring band thresholds: full marks at ≤0.07 distance (unchanged), zero points raised from 0.16 to 0.25, with adjusted curve exponent (1.4 → 1.3)

**Test coverage:**
Comprehensive test suite validates that careful tracings earn 70%+ of points, typical honest drawings earn 50%+, rough but recognizable drawings earn 25%+, while lazy circles and wrong-country tracings earn ≤5-15% on distinctive shapes.

https://claude.ai/code/session_01V4JwtUTyaheotZzBGDC5sJ