### PR TITLE
Add timed border-detective gate with hint system

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: verify
+description: Build, launch and drive this app to observe a change working at its surface.
+---
+
+# Verifying changes in mondiale
+
+## Build & launch
+
+```bash
+bun install --frozen-lockfile
+bun run build
+REDIS_PASSWORD=dev PORT=3000 node .output/server/index.mjs &
+```
+
+- The socket middleware only needs *a* redis token to boot (`REDIS_PASSWORD=dev`
+  works); Upstash is only actually called on multiplayer game events
+  (`redis.set/get/expire` in `lib/events/server-side.ts`).
+- After a rebuild, KILL the old server first — a stale process on :3000 serves
+  old HTML pointing at deleted `_nuxt` chunks (blank page, ENOENT in the log).
+
+## Surfaces
+
+- `/test-views` — dev harness for challenge/step Views: pick a scenario from the
+  select, the stub socket prints every emitted event into `.submission`
+  (truncated JSON) — the way to inspect client→server payloads without a room.
+  Add missing scenarios in `pages/test-views.vue`.
+- `/test-recognition`, `/test-pin-landmark` — sibling harnesses.
+- Full multiplayer flow needs real Upstash credentials and two browser
+  contexts (see `e2e/start-round.spec.ts`); `FORCE_INDIVIDUAL_VARIANT=<variant>`
+  forces every gate to one variant.
+
+## Driving
+
+Playwright: browsers live at `/opt/pw-browsers`; if the project-pinned version
+mismatches, launch with `executablePath: '/opt/pw-browsers/chromium'`.
+Interstitials run ~3s before a round's UI appears — wait on a round selector,
+not on time.

--- a/components/challenge/StatTopicIcon.vue
+++ b/components/challenge/StatTopicIcon.vue
@@ -69,6 +69,15 @@ const GLYPHS: Record<string, Glyph> = {
     paths: ['M3.5 7.5h17v11h-17z', 'M8.5 7.5 10 5h4l1.5 2.5'],
     circles: [[12, 13, 3.2]],
   },
+  // Not stat topics: the gate hint buttons borrow the same glyph language.
+  reveal: {
+    paths: ['M2.5 12C4.6 7.7 8 5.5 12 5.5s7.4 2.2 9.5 6.5c-2.1 4.3-5.5 6.5-9.5 6.5S4.6 16.3 2.5 12z'],
+    circles: [[12, 12, 2.9]],
+  },
+  question: {
+    paths: ['M9.3 9.2a2.75 2.75 0 1 1 4 2.45c-.85.45-1.3 1.05-1.3 1.95', 'M12 16.9v.01'],
+    circles: [[12, 12, 8.6]],
+  },
 }
 
 const FALLBACK: Glyph = { paths: ['M5 19v-7', 'M10 19V7', 'M15 19v-5', 'M20 19V9'] }

--- a/components/view/ViewIndividualChallenge.vue
+++ b/components/view/ViewIndividualChallenge.vue
@@ -99,6 +99,7 @@
                   type="button"
                   @click="showBorderHint"
                 >
+                  <span class="hint-icon eye" aria-hidden="true" />
                   Outline (−{{ GATE_HINT_BITE_STEPS }} steps)
                 </button>
               </Transition>
@@ -109,6 +110,7 @@
                   type="button"
                   @click="showIsoHint"
                 >
+                  <span class="hint-icon iso" aria-hidden="true" />
                   Country code (−{{ GATE_HINT_BITE_STEPS }} steps)
                 </button>
               </Transition>
@@ -993,9 +995,26 @@ header {
 
 .hint-button {
   cursor: pointer;
+  gap: 0.7rem;
+  display: inline-flex;
+  align-items: center;
   font-size: 1.4rem;
   font-family: inherit;
   padding: 0.6rem 1.4rem;
+
+  .hint-icon {
+    width: 1.8rem;
+    height: 1.8rem;
+    flex-shrink: 0;
+    background: var(--dark-blue);
+
+    &.eye {
+      mask: url('~/assets/icons/eye.svg') no-repeat center/contain;
+    }
+    &.iso {
+      mask: url('~/assets/icons/isoCode.svg') no-repeat center/contain;
+    }
+  }
   border-radius: 1.2rem;
   pointer-events: auto;
   color: var(--dark-blue);

--- a/components/view/ViewIndividualChallenge.vue
+++ b/components/view/ViewIndividualChallenge.vue
@@ -99,7 +99,7 @@
                   type="button"
                   @click="showBorderHint"
                 >
-                  Stuck? Reveal its outline — costs {{ GATE_HINT_BITE_STEPS }} steps
+                  Outline (−{{ GATE_HINT_BITE_STEPS }} steps)
                 </button>
               </Transition>
               <Transition name="caption">
@@ -109,7 +109,7 @@
                   type="button"
                   @click="showIsoHint"
                 >
-                  Last resort: its country code — costs {{ GATE_HINT_BITE_STEPS }} steps
+                  Country code (−{{ GATE_HINT_BITE_STEPS }} steps)
                 </button>
               </Transition>
             </div>

--- a/components/view/ViewIndividualChallenge.vue
+++ b/components/view/ViewIndividualChallenge.vue
@@ -68,9 +68,17 @@
           <!-- Border detective: name the country these neighbours surround -->
           <template v-else-if="variant === 'border-detective' && challenge.neighbours">
             <h1 class="map-caption">Who sits in the middle?</h1>
-            <span class="map-caption sub">Name the country these neighbours all border.</span>
+            <span class="map-caption sub">
+              {{ borderSecondsLeft }}s — name the country these neighbours all border
+            </span>
+            <ChallengeTimer :value="borderSecondsLeft" :total="BORDER_DETECTIVE_SECONDS" />
             <div class="border-ring" :style="{ '--ring-count': challenge.neighbours.length }">
-              <div class="ring-center" aria-hidden="true">?</div>
+              <div class="ring-center" aria-hidden="true">
+                <svg v-if="borderHint" class="hint-outline" :viewBox="borderHint.viewBox">
+                  <path :d="borderHint.d" />
+                </svg>
+                <template v-else>?</template>
+              </div>
               <div
                 v-for="(neighbour, index) in challenge.neighbours"
                 :key="neighbour"
@@ -82,6 +90,9 @@
                 <span v-if="!isHard" class="ring-name">{{ countryName(neighbour) }}</span>
               </div>
             </div>
+            <button v-if="!borderHint" class="hint-button" type="button" @click="showBorderHint">
+              Stuck? Reveal its outline — costs a step
+            </button>
             <div class="guess-box">
               <CountryGuessInput
                 :disabled="!!status"
@@ -276,6 +287,7 @@ import Interstitial from '~/components/feedback/Interstitial.vue'
 import ChallengeResult from '~/components/feedback/ChallengeResult.vue'
 import DuelReveal from '~/components/feedback/DuelReveal.vue'
 import LeaderReveal from '~/components/feedback/LeaderReveal.vue'
+import ChallengeTimer from '~/components/challenge/ChallengeTimer.vue'
 import PhotoOptionChallenge from '~/components/challenge/PhotoOptionChallenge.vue'
 import CountryGuessInput from '~/components/country/CountryGuessInput.vue'
 import { accessorTopicLabel, getChallengeDetails } from '~~/lib/challenges'
@@ -404,11 +416,44 @@ const onOutlineGuess = (country: Country) => {
 }
 
 // --- Border detective --------------------------------------------------------
+// Timed like the other mystery gates: the clock scales the leap (buzz curve,
+// applied server-side from the reported fraction) and runs out into a miss.
+const BORDER_DETECTIVE_SECONDS = 40
+const borderSecondsLeft = ref(BORDER_DETECTIVE_SECONDS)
+let borderTimer: ReturnType<typeof setInterval> | undefined
+/** The bought outline hint, drawn in the ring's centre. Buying it bites a step. */
+const borderHint = ref<{ d: string; viewBox: string }>()
+
+const beginBorderDetective = () => {
+  const active = challenge.value
+  if (!active || variant.value !== 'border-detective' || borderTimer) return
+  borderTimer = setInterval(() => {
+    borderSecondsLeft.value--
+    if (borderSecondsLeft.value <= 0) {
+      if (borderTimer) clearInterval(borderTimer)
+      if (!status.value) {
+        gameStore.map.solo = false
+        submitAnswer(wrongTokenFor(active.country))
+      }
+    }
+  }, 1000)
+}
+
+const showBorderHint = () => {
+  const active = challenge.value
+  if (!active || borderHint.value || status.value) return
+  borderHint.value = mainlandOutline(active.country)
+}
+
 const onBorderGuess = (country: Country) => {
   if (status.value) return
+  if (borderTimer) clearInterval(borderTimer)
   // Bring the world back so the result zoom has a map to land on.
   gameStore.map.solo = false
-  submitAnswer(country.isoCode)
+  submitAnswer(country.isoCode, {
+    remainingFraction: Math.max(0, borderSecondsLeft.value) / BORDER_DETECTIVE_SECONDS,
+    hintUsed: !!borderHint.value,
+  })
 }
 
 // --- Zoom-out ----------------------------------------------------------------
@@ -561,13 +606,21 @@ const incorrectMessage = computed(() => {
   }
 })
 
-const submitAnswer = (isoCode: ISOCountryCode, options: { reveal?: boolean } = {}) => {
+const submitAnswer = (
+  isoCode: ISOCountryCode,
+  options: { reveal?: boolean; remainingFraction?: number; hintUsed?: boolean } = {}
+) => {
   if (status.value) return
   if (currentMove.value?.challenge?._type === 'final-challenge') return
 
   submittedISOCode.value = isoCode
   gameStore.map.highlighted.clear()
-  update({ event: 'submit-individual-challenge-answer', isoCode })
+  update({
+    event: 'submit-individual-challenge-answer',
+    isoCode,
+    remainingFraction: options.remainingFraction,
+    hintUsed: options.hintUsed,
+  })
 
   const active = currentMove.value?.challenge
   if (active) {
@@ -584,6 +637,7 @@ watch(showInterstitial, value => {
   if (value) return
   if (variant.value === 'outline-reveal') beginOutlineReveal()
   if (variant.value === 'zoom-out') beginZoomOut()
+  if (variant.value === 'border-detective') beginBorderDetective()
 })
 
 // Back-to-back gates can reach a still-mounted view (the walk between them
@@ -608,6 +662,12 @@ watch(currentMove, move => {
   }
   resetOutlineReveal()
   outlineSecondsLeft.value = OUTLINE_REVEAL_SECONDS
+  if (borderTimer) {
+    clearInterval(borderTimer)
+    borderTimer = undefined
+  }
+  borderHint.value = undefined
+  borderSecondsLeft.value = BORDER_DETECTIVE_SECONDS
   if (zoomOutTimer) {
     clearTimeout(zoomOutTimer)
     zoomOutTimer = undefined
@@ -658,6 +718,7 @@ onBeforeMount(() => {
 onBeforeUnmount(() => {
   clearBoard()
   if (outlineTimer) clearInterval(outlineTimer)
+  if (borderTimer) clearInterval(borderTimer)
   if (zoomOutTimer) clearTimeout(zoomOutTimer)
   resetOutlineReveal()
   document.removeEventListener('mapClick', onMapClick)
@@ -851,6 +912,44 @@ header {
     height: auto;
     border-radius: 0.3rem;
     filter: drop-shadow(0 1px 3px hsla(215.7, 76.4%, 21.6%, 0.25));
+  }
+}
+
+// The bought hint: the mystery country's outline takes over the "?" circle.
+.ring-center .hint-outline {
+  width: 76%;
+  height: 76%;
+
+  path {
+    fill: none;
+    stroke: var(--dark-blue);
+    stroke-width: 1.5;
+    vector-effect: non-scaling-stroke;
+    stroke-linejoin: round;
+    stroke-linecap: round;
+  }
+}
+
+.hint-button {
+  cursor: pointer;
+  font-size: 1.4rem;
+  font-family: inherit;
+  padding: 0.6rem 1.4rem;
+  border-radius: 1.2rem;
+  pointer-events: auto;
+  color: var(--dark-blue);
+  backdrop-filter: blur(0.5rem);
+  background: hsla(36, 100%, 98%, 0.88);
+  border: 0.1rem solid hsla(215.7, 76.4%, 21.6%, 0.25);
+  transition: border-color var(--motion-quick) var(--ease-out-expressive);
+
+  @media (hover: hover) {
+    &:hover {
+      border-color: var(--dark-blue);
+    }
+  }
+  &:active {
+    border-color: var(--dark-blue);
   }
 }
 

--- a/components/view/ViewIndividualChallenge.vue
+++ b/components/view/ViewIndividualChallenge.vue
@@ -74,6 +74,7 @@
             <ChallengeTimer :value="borderSecondsLeft" :total="BORDER_DETECTIVE_SECONDS" />
             <div class="border-ring" :style="{ '--ring-count': challenge.neighbours.length }">
               <div class="ring-center" aria-hidden="true">
+                <span v-if="isoHint" class="iso-chip">{{ isoHint }}</span>
                 <svg v-if="borderHint" class="hint-outline" :viewBox="borderHint.viewBox">
                   <path :d="borderHint.d" />
                 </svg>
@@ -90,9 +91,28 @@
                 <span v-if="!isHard" class="ring-name">{{ countryName(neighbour) }}</span>
               </div>
             </div>
-            <button v-if="!borderHint" class="hint-button" type="button" @click="showBorderHint">
-              Stuck? Reveal its outline — costs a step
-            </button>
+            <div class="hint-row">
+              <Transition name="caption">
+                <button
+                  v-if="!borderHint && outlineHintUnlocked"
+                  class="hint-button"
+                  type="button"
+                  @click="showBorderHint"
+                >
+                  Stuck? Reveal its outline — costs {{ GATE_HINT_BITE_STEPS }} steps
+                </button>
+              </Transition>
+              <Transition name="caption">
+                <button
+                  v-if="!isoHint && isoHintUnlocked"
+                  class="hint-button"
+                  type="button"
+                  @click="showIsoHint"
+                >
+                  Last resort: its country code — costs {{ GATE_HINT_BITE_STEPS }} steps
+                </button>
+              </Transition>
+            </div>
             <div class="guess-box">
               <CountryGuessInput
                 :disabled="!!status"
@@ -296,6 +316,8 @@ import { currencySymbol } from '~~/lib/currency'
 import { politicalLeader } from '~~/lib/leaders'
 import { useClientEvents } from '~~/lib/events/client-side'
 import { useOutlineReveal } from '~~/lib/useOutlineReveal'
+import { GATE_HINT_BITE_STEPS } from '~~/lib/scoring'
+import { mainlandOutline } from '~~/lib/outline'
 import { getValueByAccessorID, processReplacements } from '~~/lib/values'
 import { isMapClickEvent } from '~~/types/events.types'
 import type { Country, ISOCountryCode } from '~~/types/geography.types'
@@ -419,10 +441,19 @@ const onOutlineGuess = (country: Country) => {
 // Timed like the other mystery gates: the clock scales the leap (buzz curve,
 // applied server-side from the reported fraction) and runs out into a miss.
 const BORDER_DETECTIVE_SECONDS = 40
+/** Hints unlock in waves: the outline a third in, the ISO code two thirds in. */
+const OUTLINE_HINT_UNLOCK_ELAPSED = 1 / 3
+const ISO_HINT_UNLOCK_ELAPSED = 2 / 3
 const borderSecondsLeft = ref(BORDER_DETECTIVE_SECONDS)
 let borderTimer: ReturnType<typeof setInterval> | undefined
-/** The bought outline hint, drawn in the ring's centre. Buying it bites a step. */
+/** The bought outline hint, drawn in the ring's centre. Every hint bites steps. */
 const borderHint = ref<{ d: string; viewBox: string }>()
+/** The bought last-resort hint: the country's ISO code, chipped onto the ring. */
+const isoHint = ref<ISOCountryCode>()
+const elapsedFraction = computed(() => 1 - borderSecondsLeft.value / BORDER_DETECTIVE_SECONDS)
+const outlineHintUnlocked = computed(() => elapsedFraction.value >= OUTLINE_HINT_UNLOCK_ELAPSED)
+const isoHintUnlocked = computed(() => elapsedFraction.value >= ISO_HINT_UNLOCK_ELAPSED)
+const hintsUsed = computed(() => (borderHint.value ? 1 : 0) + (isoHint.value ? 1 : 0))
 
 const beginBorderDetective = () => {
   const active = challenge.value
@@ -445,6 +476,12 @@ const showBorderHint = () => {
   borderHint.value = mainlandOutline(active.country)
 }
 
+const showIsoHint = () => {
+  const active = challenge.value
+  if (!active || isoHint.value || status.value) return
+  isoHint.value = active.country
+}
+
 const onBorderGuess = (country: Country) => {
   if (status.value) return
   if (borderTimer) clearInterval(borderTimer)
@@ -452,7 +489,7 @@ const onBorderGuess = (country: Country) => {
   gameStore.map.solo = false
   submitAnswer(country.isoCode, {
     remainingFraction: Math.max(0, borderSecondsLeft.value) / BORDER_DETECTIVE_SECONDS,
-    hintUsed: !!borderHint.value,
+    hintsUsed: hintsUsed.value,
   })
 }
 
@@ -608,7 +645,7 @@ const incorrectMessage = computed(() => {
 
 const submitAnswer = (
   isoCode: ISOCountryCode,
-  options: { reveal?: boolean; remainingFraction?: number; hintUsed?: boolean } = {}
+  options: { reveal?: boolean; remainingFraction?: number; hintsUsed?: number } = {}
 ) => {
   if (status.value) return
   if (currentMove.value?.challenge?._type === 'final-challenge') return
@@ -619,7 +656,7 @@ const submitAnswer = (
     event: 'submit-individual-challenge-answer',
     isoCode,
     remainingFraction: options.remainingFraction,
-    hintUsed: options.hintUsed,
+    hintsUsed: options.hintsUsed,
   })
 
   const active = currentMove.value?.challenge
@@ -667,6 +704,7 @@ watch(currentMove, move => {
     borderTimer = undefined
   }
   borderHint.value = undefined
+  isoHint.value = undefined
   borderSecondsLeft.value = BORDER_DETECTIVE_SECONDS
   if (zoomOutTimer) {
     clearTimeout(zoomOutTimer)
@@ -928,6 +966,29 @@ header {
     stroke-linejoin: round;
     stroke-linecap: round;
   }
+}
+
+// The bought last resort: the ISO code chipped over the circle's top edge.
+.ring-center .iso-chip {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -55%);
+  font-size: 1.6rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  padding: 0.2rem 0.9rem 0.2rem 1.08rem; // optical: balance the tracking's tail
+  border-radius: 1rem;
+  color: var(--dark-blue);
+  background: hsla(36, 100%, 98%, 0.92);
+  border: 0.1rem solid hsla(215.7, 76.4%, 21.6%, 0.3);
+}
+
+.hint-row {
+  gap: 1rem;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
 }
 
 .hint-button {

--- a/components/view/ViewIndividualChallenge.vue
+++ b/components/view/ViewIndividualChallenge.vue
@@ -99,7 +99,7 @@
                   type="button"
                   @click="showBorderHint"
                 >
-                  <span class="hint-icon eye" aria-hidden="true" />
+                  <StatTopicIcon class="hint-icon" topic="reveal" />
                   Outline (−{{ GATE_HINT_BITE_STEPS }} steps)
                 </button>
               </Transition>
@@ -110,7 +110,7 @@
                   type="button"
                   @click="showIsoHint"
                 >
-                  <span class="hint-icon iso" aria-hidden="true" />
+                  <StatTopicIcon class="hint-icon" topic="question" />
                   Country code (−{{ GATE_HINT_BITE_STEPS }} steps)
                 </button>
               </Transition>
@@ -310,6 +310,7 @@ import ChallengeResult from '~/components/feedback/ChallengeResult.vue'
 import DuelReveal from '~/components/feedback/DuelReveal.vue'
 import LeaderReveal from '~/components/feedback/LeaderReveal.vue'
 import ChallengeTimer from '~/components/challenge/ChallengeTimer.vue'
+import StatTopicIcon from '~/components/challenge/StatTopicIcon.vue'
 import PhotoOptionChallenge from '~/components/challenge/PhotoOptionChallenge.vue'
 import CountryGuessInput from '~/components/country/CountryGuessInput.vue'
 import { accessorTopicLabel, getChallengeDetails } from '~~/lib/challenges'
@@ -1003,17 +1004,7 @@ header {
   padding: 0.6rem 1.4rem;
 
   .hint-icon {
-    width: 1.8rem;
-    height: 1.8rem;
     flex-shrink: 0;
-    background: var(--dark-blue);
-
-    &.eye {
-      mask: url('~/assets/icons/eye.svg') no-repeat center/contain;
-    }
-    &.iso {
-      mask: url('~/assets/icons/isoCode.svg') no-repeat center/contain;
-    }
   }
   border-radius: 1.2rem;
   pointer-events: auto;

--- a/lib/events/server/submit-individual-challenge-answer.handler.ts
+++ b/lib/events/server/submit-individual-challenge-answer.handler.ts
@@ -33,8 +33,8 @@ export const submitIndividualChallengeAnswersHandler = defineGameHandler(
 
     const correct = eventData.isoCode === currentMove.challenge.country
     if (correct) {
-      // Timed gates scale the leap by the clock; a bought hint bites a step.
-      player.currentPosition += gateLeapSteps(eventData.remainingFraction, eventData.hintUsed)
+      // Timed gates scale the leap by the clock; bought hints bite steps off.
+      player.currentPosition += gateLeapSteps(eventData.remainingFraction, eventData.hintsUsed)
       player.moves.shift()
     } else {
       player.moves = []

--- a/lib/events/server/submit-individual-challenge-answer.handler.ts
+++ b/lib/events/server/submit-individual-challenge-answer.handler.ts
@@ -1,3 +1,4 @@
+import { gateLeapSteps } from '~~/lib/scoring'
 import { defineGameHandler, enqueueGameTask } from '../server-side'
 import { enterMovementPhaseHandler } from './enter-movement-phase.handler'
 
@@ -32,7 +33,8 @@ export const submitIndividualChallengeAnswersHandler = defineGameHandler(
 
     const correct = eventData.isoCode === currentMove.challenge.country
     if (correct) {
-      player.currentPosition += 2
+      // Timed gates scale the leap by the clock; a bought hint bites a step.
+      player.currentPosition += gateLeapSteps(eventData.remainingFraction, eventData.hintUsed)
       player.moves.shift()
     } else {
       player.moves = []

--- a/lib/scoring.test.ts
+++ b/lib/scoring.test.ts
@@ -7,7 +7,14 @@ import {
   scoreHotCold,
   scoreTraversalSubmission,
 } from './challenges'
-import { attemptFraction, blitzScore, buzzFraction, GATE_LEAP_STEPS, gateLeapSteps } from './scoring'
+import {
+  attemptFraction,
+  blitzScore,
+  buzzFraction,
+  GATE_HINT_BITE_STEPS,
+  GATE_LEAP_STEPS,
+  gateLeapSteps,
+} from './scoring'
 import type { GhostStateChallenge, HotColdChallenge } from '~~/types/challenges/group-modes.type'
 import type { TraversalChallenge } from '~~/types/challenges/traversal-challenge.type'
 import type { ISOCountryCode } from '~~/types/geography.types'
@@ -149,9 +156,16 @@ describe('gateLeapSteps', () => {
     expect(gateLeapSteps(0)).toBe(1)
   })
 
-  it('bites one step for the outline hint, never below zero', () => {
-    expect(gateLeapSteps(1, true)).toBe(1)
-    expect(gateLeapSteps(0, true)).toBe(0)
+  it('bites GATE_HINT_BITE_STEPS per bought hint, never below zero', () => {
+    expect(gateLeapSteps(1, 1)).toBe(Math.max(0, GATE_LEAP_STEPS - GATE_HINT_BITE_STEPS))
+    expect(gateLeapSteps(0, 1)).toBe(0)
+    expect(gateLeapSteps(1, 2)).toBe(0)
+  })
+
+  it('never lets a negative or garbage hint count inflate the leap', () => {
+    expect(gateLeapSteps(1, -3)).toBe(GATE_LEAP_STEPS)
+    expect(gateLeapSteps(1, Number.NaN)).toBe(GATE_LEAP_STEPS)
+    expect(gateLeapSteps(1, 0.4)).toBe(GATE_LEAP_STEPS)
   })
 
   it('shrugs off a garbage fraction instead of walking the pawn NaN steps', () => {

--- a/lib/scoring.test.ts
+++ b/lib/scoring.test.ts
@@ -7,7 +7,7 @@ import {
   scoreHotCold,
   scoreTraversalSubmission,
 } from './challenges'
-import { attemptFraction, blitzScore, buzzFraction } from './scoring'
+import { attemptFraction, blitzScore, buzzFraction, GATE_LEAP_STEPS, gateLeapSteps } from './scoring'
 import type { GhostStateChallenge, HotColdChallenge } from '~~/types/challenges/group-modes.type'
 import type { TraversalChallenge } from '~~/types/challenges/traversal-challenge.type'
 import type { ISOCountryCode } from '~~/types/geography.types'
@@ -134,6 +134,31 @@ describe('buzzFraction', () => {
     for (const f of [0, 0.13, 0.5, 0.87, 1]) {
       expect(buzzFraction(f)).toBeCloseTo(0.35 + 0.65 * f, 12)
     }
+  })
+})
+
+describe('gateLeapSteps', () => {
+  it('pays the whole pot when no clock is reported (untimed gates)', () => {
+    expect(gateLeapSteps()).toBe(GATE_LEAP_STEPS)
+  })
+
+  it('pays the pot for a fast answer, one step for a slow one', () => {
+    expect(gateLeapSteps(1)).toBe(2)
+    expect(gateLeapSteps(0.7)).toBe(2)
+    expect(gateLeapSteps(0.5)).toBe(1)
+    expect(gateLeapSteps(0)).toBe(1)
+  })
+
+  it('bites one step for the outline hint, never below zero', () => {
+    expect(gateLeapSteps(1, true)).toBe(1)
+    expect(gateLeapSteps(0, true)).toBe(0)
+  })
+
+  it('shrugs off a garbage fraction instead of walking the pawn NaN steps', () => {
+    expect(gateLeapSteps(Number.NaN)).toBe(GATE_LEAP_STEPS)
+    expect(gateLeapSteps(Number.POSITIVE_INFINITY)).toBe(GATE_LEAP_STEPS)
+    expect(gateLeapSteps(7)).toBe(2)
+    expect(gateLeapSteps(-3)).toBe(1)
   })
 })
 

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -17,18 +17,24 @@ export const buzzScore = (maximumPoints: number, remainingFraction: number): num
 /** A gate's full-pot leap in board steps — what an untimed gate always pays. */
 export const GATE_LEAP_STEPS = 2
 
+/** Each bought gate hint bites this many steps off the leap. */
+export const GATE_HINT_BITE_STEPS = 2
+
 /**
  * Steps a correct gate answer moves the pawn. Timed gates report the clock
- * fraction left and the buzz curve scales the leap; a bought hint bites one
- * step. Untimed gates report nothing and pay the whole pot. A non-finite
- * fraction (a hostile or buggy client) falls back to the pot rather than NaN.
+ * fraction left and the buzz curve scales the leap; every bought hint bites
+ * `GATE_HINT_BITE_STEPS`, never below zero. Untimed gates report nothing and
+ * pay the whole pot. Hostile or buggy payloads can't help themselves: a
+ * non-finite fraction falls back to the pot, and a negative or non-finite
+ * hint count bites nothing rather than paying extra.
  */
-export const gateLeapSteps = (remainingFraction?: number, hintUsed = false): number => {
+export const gateLeapSteps = (remainingFraction?: number, hintsUsed = 0): number => {
   const pot =
     remainingFraction !== undefined && Number.isFinite(remainingFraction)
       ? Math.round(GATE_LEAP_STEPS * buzzFraction(remainingFraction))
       : GATE_LEAP_STEPS
-  return Math.max(0, pot - (hintUsed ? 1 : 0))
+  const bought = Number.isFinite(hintsUsed) ? Math.max(0, Math.floor(hintsUsed)) : 0
+  return Math.max(0, pot - bought * GATE_HINT_BITE_STEPS)
 }
 
 /**

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -14,6 +14,23 @@ export const buzzFraction = (remainingFraction: number): number =>
 export const buzzScore = (maximumPoints: number, remainingFraction: number): number =>
   Math.round(maximumPoints * buzzFraction(remainingFraction))
 
+/** A gate's full-pot leap in board steps — what an untimed gate always pays. */
+export const GATE_LEAP_STEPS = 2
+
+/**
+ * Steps a correct gate answer moves the pawn. Timed gates report the clock
+ * fraction left and the buzz curve scales the leap; a bought hint bites one
+ * step. Untimed gates report nothing and pay the whole pot. A non-finite
+ * fraction (a hostile or buggy client) falls back to the pot rather than NaN.
+ */
+export const gateLeapSteps = (remainingFraction?: number, hintUsed = false): number => {
+  const pot =
+    remainingFraction !== undefined && Number.isFinite(remainingFraction)
+      ? Math.round(GATE_LEAP_STEPS * buzzFraction(remainingFraction))
+      : GATE_LEAP_STEPS
+  return Math.max(0, pot - (hintUsed ? 1 : 0))
+}
+
 /**
  * Blitz-family scoring (water modes, mother-tongue, neighbour-blitz): the
  * found ratio scales the pot, every wrong guess bites one point. Duplicate

--- a/pages/test-views.vue
+++ b/pages/test-views.vue
@@ -67,7 +67,7 @@ const installStubSocket = () => {
   gameStore.playerId = ME
   gameStore.socket = {
     emit: (event: string, eventData: Record<string, unknown>) => {
-      lastEvent.value = `${event} ${JSON.stringify(eventData ?? {}).slice(0, 80)}`
+      lastEvent.value = `${event} ${JSON.stringify(eventData ?? {}).slice(0, 160)}`
     },
   } as never
 }
@@ -349,6 +349,17 @@ const scenarios: Scenario[] = [
     label: 'Individual: zoom-out (typed)',
     component: ViewIndividualChallenge,
     build: () => individualGame({ variant: 'zoom-out', country: 'MY' }),
+  },
+  {
+    id: 'individual-border-detective',
+    label: 'Individual: border detective (timed, hint)',
+    component: ViewIndividualChallenge,
+    build: () =>
+      individualGame({
+        variant: 'border-detective',
+        country: 'HU',
+        neighbours: ['AT', 'SK', 'UA', 'RO', 'RS', 'HR', 'SI'],
+      }),
   },
   {
     id: 'individual-higher-lower',

--- a/types/challenges/individual-challenge.type.ts
+++ b/types/challenges/individual-challenge.type.ts
@@ -42,8 +42,8 @@ export interface IndividualChallenge {
   }
   /** border-detective: the mystery country's neighbours, shown as a flag ring
    *  (the answer `country` is NOT among them — it sits in the empty centre).
-   *  Timed: the clock fraction left scales the leap, and an optional outline
-   *  hint costs a step (see `gateLeapSteps`). */
+   *  Timed: the clock fraction left scales the leap, and an outline hint
+   *  (unlocked a third of the way in) costs steps (see `gateLeapSteps`). */
   neighbours?: ISOCountryCode[]
   /** capital-match / photo gates: a photo (capital skyline, landmark) whose
    *  country the player names from `options`. */

--- a/types/challenges/individual-challenge.type.ts
+++ b/types/challenges/individual-challenge.type.ts
@@ -41,7 +41,9 @@ export interface IndividualChallenge {
     name: string
   }
   /** border-detective: the mystery country's neighbours, shown as a flag ring
-   *  (the answer `country` is NOT among them — it sits in the empty centre). */
+   *  (the answer `country` is NOT among them — it sits in the empty centre).
+   *  Timed: the clock fraction left scales the leap, and an optional outline
+   *  hint costs a step (see `gateLeapSteps`). */
   neighbours?: ISOCountryCode[]
   /** capital-match / photo gates: a photo (capital skyline, landmark) whose
    *  country the player names from `options`. */

--- a/types/events.types.ts
+++ b/types/events.types.ts
@@ -47,6 +47,11 @@ export type ClientEventData =
   | {
       event: 'submit-individual-challenge-answer'
       isoCode: ISOCountryCode
+      /** Timed gates (border-detective): fraction of the clock left at submit.
+       *  Scales the leap via the buzz curve; the server clamps it. */
+      remainingFraction?: number
+      /** Timed gates: an outline hint was bought — bites one step off the leap. */
+      hintUsed?: boolean
     }
   | {
       event: 'close-tutorial'

--- a/types/events.types.ts
+++ b/types/events.types.ts
@@ -50,8 +50,9 @@ export type ClientEventData =
       /** Timed gates (border-detective): fraction of the clock left at submit.
        *  Scales the leap via the buzz curve; the server clamps it. */
       remainingFraction?: number
-      /** Timed gates: an outline hint was bought — bites one step off the leap. */
-      hintUsed?: boolean
+      /** Timed gates: how many hints were bought (outline, ISO code) — each
+       *  bites `GATE_HINT_BITE_STEPS` off the leap, floored at zero. */
+      hintsUsed?: number
     }
   | {
       event: 'close-tutorial'


### PR DESCRIPTION
Implements the border-detective challenge variant as a timed gate with a progressive hint unlock system.

## Summary
The border-detective challenge now runs on a 40-second timer that scales the board leap via the buzz curve. Players can unlock two hints as time elapses: an outline reveal at 1/3 elapsed, and the country's ISO code at 2/3 elapsed. Each hint costs steps off the leap reward.

## Key Changes
- **Timer & Scoring**: Added 40-second countdown that triggers a miss on timeout. Correct answers report remaining time fraction to scale the leap via `gateLeapSteps()`, which also deducts steps for purchased hints.
- **Hint System**: Two progressive hints unlock at elapsed time thresholds—outline (1/3) and ISO code (2/3)—each costing `GATE_HINT_BITE_STEPS` (2 steps). Hints render in the ring's center: outline as an SVG path, ISO code as a chip badge.
- **Scoring Logic**: Centralized `gateLeapSteps()` function handles timed/untimed gates, buzz scaling, and hint deductions with defensive handling for invalid payloads.
- **Event Payload**: `submit-individual-challenge-answer` now includes optional `remainingFraction` and `hintsUsed` fields for timed gates; server-side handler applies the new scoring function.
- **UI**: Added hint unlock buttons with transitions, timer display, and visual feedback in the ring center. Test harness updated with border-detective scenario.

## Implementation Details
- Hints are bought on-demand (not auto-unlocked) to allow strategic timing decisions.
- Timer cleanup on component unmount and challenge transitions prevents memory leaks.
- Defensive validation in `gateLeapSteps()` ensures garbage payloads fall back to full pot or zero hints rather than inflating rewards.

https://claude.ai/code/session_01BWqrEQ1DdNNZnSnTsiB6Ln