### PR TITLE
Extract outline reveal choreography into reusable composable

### DIFF
--- a/components/view/ViewIndividualChallenge.vue
+++ b/components/view/ViewIndividualChallenge.vue
@@ -8,7 +8,12 @@
     />
     <header v-else>
       <Transition name="caption" mode="out-in">
-        <div v-if="!status" key="question" class="question" :class="{ 'text-guess': textGuessVariant }">
+        <div
+          v-if="!status"
+          key="question"
+          class="question"
+          :class="{ 'text-guess': textGuessVariant }"
+        >
           <!-- Classic find-on-the-map -->
           <template v-if="variant === 'find'">
             <h1 class="map-caption">
@@ -209,7 +214,11 @@
               :viewBox="outlineReveal.viewBox"
               aria-hidden="true"
             >
-              <path ref="outlineRevealPath" :d="outlineReveal.d" />
+              <path
+                ref="outlineRevealPath"
+                :d="outlineReveal.d"
+                :stroke-width="outlineReveal.strokeWidth"
+              />
             </svg>
             <div class="guess-box">
               <CountryGuessInput
@@ -274,8 +283,7 @@ import { countryName, getCountry } from '~~/lib/country'
 import { currencySymbol } from '~~/lib/currency'
 import { politicalLeader } from '~~/lib/leaders'
 import { useClientEvents } from '~~/lib/events/client-side'
-import { prefersReducedMotion } from '~~/lib/motion'
-import { mainlandOutline } from '~~/lib/outline'
+import { useOutlineReveal } from '~~/lib/useOutlineReveal'
 import { getValueByAccessorID, processReplacements } from '~~/lib/values'
 import { isMapClickEvent } from '~~/types/events.types'
 import type { Country, ISOCountryCode } from '~~/types/geography.types'
@@ -349,8 +357,15 @@ const interstitialTitle = computed(() => {
 
 // --- Outline reveal race (hard) ------------------------------------------------
 const OUTLINE_REVEAL_SECONDS = 25
-const outlineReveal = ref<{ d: string; viewBox: string }>()
-const outlineRevealPath = ref<SVGPathElement>()
+// Preview flash → sweep-away → clock-synced border draw, all size-relative.
+const {
+  outline: outlineReveal,
+  outlinePath: outlineRevealPath,
+  prepareOutline,
+  beginOutlineReveal: beginOutlineDraw,
+  tickOutlineReveal,
+  resetOutlineReveal,
+} = useOutlineReveal()
 const outlineSecondsLeft = ref(OUTLINE_REVEAL_SECONDS)
 let outlineTimer: ReturnType<typeof setInterval> | undefined
 
@@ -360,39 +375,23 @@ const wrongTokenFor = (correct: ISOCountryCode): ISOCountryCode => (correct === 
 const beginOutlineReveal = () => {
   const active = challenge.value
   if (!active || variant.value !== 'outline-reveal' || outlineTimer) return
-  outlineReveal.value = mainlandOutline(active.country)
+  prepareOutline(active.country)
+  beginOutlineDraw(OUTLINE_REVEAL_SECONDS)
 
-  nextTick(() => {
-    const path = outlineRevealPath.value
-    const length = path?.getTotalLength() ?? 0
-    if (!path || !length) return
+  // The clock runs regardless of the outline resolving — the gate must never
+  // hang without its timeout just because the geometry was missing.
+  outlineTimer = setInterval(() => {
+    outlineSecondsLeft.value--
+    tickOutlineReveal(outlineSecondsLeft.value)
 
-    // Continuous dash-reveal in the path's real length units (px-valued dash
-    // properties bypass pathLength normalization — see ViewSilhouette)
-    path.style.strokeDasharray = `${length}`
-    path.style.strokeDashoffset = prefersReducedMotion() ? '0' : `${length}`
-    path.style.transition = 'stroke-dashoffset 1s linear'
-
-    outlineTimer = setInterval(() => {
-      outlineSecondsLeft.value--
-
-      if (!prefersReducedMotion()) {
-        const revealed = Math.min(
-          1,
-          (OUTLINE_REVEAL_SECONDS - outlineSecondsLeft.value) / (OUTLINE_REVEAL_SECONDS * 0.85)
-        )
-        path.style.strokeDashoffset = `${length * (1 - revealed)}`
+    if (outlineSecondsLeft.value <= 0) {
+      if (outlineTimer) clearInterval(outlineTimer)
+      if (!status.value) {
+        gameStore.map.solo = false
+        submitAnswer(wrongTokenFor(active.country))
       }
-
-      if (outlineSecondsLeft.value <= 0) {
-        if (outlineTimer) clearInterval(outlineTimer)
-        if (!status.value) {
-          gameStore.map.solo = false
-          submitAnswer(wrongTokenFor(active.country))
-        }
-      }
-    }, 1000)
-  })
+    }
+  }, 1000)
 }
 
 const onOutlineGuess = (country: Country) => {
@@ -607,7 +606,7 @@ watch(currentMove, move => {
     clearInterval(outlineTimer)
     outlineTimer = undefined
   }
-  outlineReveal.value = undefined
+  resetOutlineReveal()
   outlineSecondsLeft.value = OUTLINE_REVEAL_SECONDS
   if (zoomOutTimer) {
     clearTimeout(zoomOutTimer)
@@ -660,6 +659,7 @@ onBeforeUnmount(() => {
   clearBoard()
   if (outlineTimer) clearInterval(outlineTimer)
   if (zoomOutTimer) clearTimeout(zoomOutTimer)
+  resetOutlineReveal()
   document.removeEventListener('mapClick', onMapClick)
 })
 </script>
@@ -945,11 +945,11 @@ header {
   max-width: 62vw;
   margin-top: 0.6rem;
 
+  // Stroke width arrives as a user-unit attribute scaled to the country's
+  // frame — non-scaling-stroke would shatter the dash-reveal (see outline.ts).
   path {
     fill: none;
     stroke: var(--dark-blue);
-    stroke-width: 1.5;
-    vector-effect: non-scaling-stroke;
     stroke-linejoin: round;
     stroke-linecap: round;
   }

--- a/components/view/ViewSilhouette.vue
+++ b/components/view/ViewSilhouette.vue
@@ -5,7 +5,7 @@
       tone="info"
       :kicker="`Round ${currentRound?.number ?? 1} — Silhouette`"
       title="Whose outline is this?"
-      :stakes="`The outline draws itself over ${challenge.durationSeconds} seconds — buzz in early for more points. A wrong buzz locks you out for a moment.`"
+      :stakes="`The outline flashes whole, then draws itself back in over ${challenge.durationSeconds} seconds — buzz in early for more points. A wrong buzz locks you out for a moment.`"
       @done="begin"
     />
 
@@ -30,7 +30,7 @@
 
     <section v-show="!resolved" class="outline-stage">
       <svg v-if="outline" class="outline" :viewBox="outline.viewBox" aria-hidden="true">
-        <path ref="outlinePath" :d="outline.d" />
+        <path ref="outlinePath" :d="outline.d" :stroke-width="outline.strokeWidth" />
       </svg>
     </section>
 
@@ -52,17 +52,15 @@
   </div>
 </template>
 <script lang="ts" setup>
-import { gsap } from 'gsap'
 import ChallengeTimer from '~/components/challenge/ChallengeTimer.vue'
 import CountryGuessInput from '~/components/country/CountryGuessInput.vue'
 import GuessTicker from '~/components/feedback/GuessTicker.vue'
 import Interstitial from '~/components/feedback/Interstitial.vue'
 import { BORDERS } from '~~/data/borders.gen'
 import { countryName } from '~~/lib/country'
-import { prefersReducedMotion } from '~~/lib/motion'
-import { mainlandOutline } from '~~/lib/outline'
 import { buzzScore } from '~~/lib/scoring'
 import { useGroupChallenge } from '~~/lib/useGroupChallenge'
+import { useOutlineReveal } from '~~/lib/useOutlineReveal'
 import type { Country, ISOCountryCode } from '~~/types/geography.types'
 
 // Blank the world map — the silhouette IS the whole question
@@ -93,14 +91,18 @@ const regionRevealed = computed(() => {
   const total = challenge.value?.durationSeconds ?? 30
   return started.value && secondsLeft.value / total <= 0.3
 })
-const outlinePath = ref<SVGPathElement>()
-
-/** The country's mainland ring, framed in its own viewBox. */
-const outline = ref<{ d: string; viewBox: string }>()
+// Preview flash → sweep-away → clock-synced border draw, all size-relative.
+const {
+  outline,
+  outlinePath,
+  prepareOutline,
+  beginOutlineReveal,
+  tickOutlineReveal,
+  resetOutlineReveal,
+} = useOutlineReveal()
 onMounted(() => {
   const active = challenge.value
-  if (!active) return
-  outline.value = mainlandOutline(active.country)
+  if (active) prepareOutline(active.country)
 })
 
 let lockoutTimer: ReturnType<typeof setTimeout> | undefined
@@ -108,7 +110,7 @@ let revealTimer: ReturnType<typeof setTimeout> | undefined
 registerCleanup(() => {
   if (lockoutTimer) clearTimeout(lockoutTimer)
   if (revealTimer) clearTimeout(revealTimer)
-  if (outlinePath.value) gsap.killTweensOf(outlinePath.value)
+  resetOutlineReveal()
 })
 
 const submitRound = (guess: ISOCountryCode | undefined, clientScore: number) => {
@@ -146,32 +148,9 @@ const resolve = (guess: ISOCountryCode | undefined, clientScore: number) => {
 }
 
 const begin = () => {
-  const active = challenge.value
-
-  // Dash-reveal in the path's REAL length units. The pathLength="1" trick is
-  // a trap here: values written with px units (as animation libraries do)
-  // bypass pathLength normalization in Chrome, leaving a frozen confetti of
-  // 1px dashes. getTotalLength + a CSS transition is boringly reliable.
-  const path = outlinePath.value
-  const outlineLength = path?.getTotalLength() ?? 0
-  if (path && outlineLength) {
-    path.style.strokeDasharray = `${outlineLength}`
-    path.style.strokeDashoffset = prefersReducedMotion() ? '0' : `${outlineLength}`
-    // Updated once per countdown tick with a linear 1s transition — the line
-    // creeps around the border in one continuous, ever-growing stroke
-    path.style.transition = 'stroke-dashoffset 1s linear'
-  }
-
+  beginOutlineReveal(challenge.value?.durationSeconds ?? 30)
   beginRound({
-    onTick: remaining => {
-      const total = active?.durationSeconds ?? 30
-      if (path && outlineLength && !prefersReducedMotion()) {
-        // The full border lands at ~85% of the clock, leaving a beat to study
-        // the complete shape before time runs out
-        const revealed = Math.min(1, (total - remaining) / (total * 0.85))
-        path.style.strokeDashoffset = `${outlineLength * (1 - revealed)}`
-      }
-    },
+    onTick: tickOutlineReveal,
     onTimeout: () => resolve(undefined, 0),
   })
   nextTick(() => guessInput.value?.focus())
@@ -254,11 +233,11 @@ header {
   max-height: 44vh;
   max-width: 70vw;
 
+  // Stroke width arrives as a user-unit attribute scaled to the country's
+  // frame — non-scaling-stroke would shatter the dash-reveal (see outline.ts).
   path {
     fill: none;
     stroke: var(--dark-blue);
-    stroke-width: 1.5;
-    vector-effect: non-scaling-stroke;
     stroke-linejoin: round;
     stroke-linecap: round;
   }

--- a/lib/outline.test.ts
+++ b/lib/outline.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { largestRing, normalizeOutline, resampleClosed, scoreSketch } from './outline'
+import {
+  DRAW_COMPLETE_AT,
+  drawnFraction,
+  largestRing,
+  normalizeOutline,
+  previewSweepSeconds,
+  resampleClosed,
+  scoreSketch,
+} from './outline'
 import type { OutlinePoint } from './outline'
 import { MAP_PATHS } from '~~/data/map.gen'
 
@@ -40,10 +48,7 @@ const handDrawn = (
   const count = base.length
   const wobbled: OutlinePoint[] = base.map(([x, y], index) => {
     const angle = (index / count) * Math.PI * 2
-    return [
-      x + Math.cos(angle * 3 + 1) * quality.wobble,
-      y + Math.sin(angle * 2) * quality.wobble,
-    ]
+    return [x + Math.cos(angle * 3 + 1) * quality.wobble, y + Math.sin(angle * 2) * quality.wobble]
   })
   const cos = Math.cos(quality.tilt)
   const sin = Math.sin(quality.tilt)
@@ -117,5 +122,70 @@ describe('scoreSketch', () => {
     // for a genuinely confusable silhouette is fine, a real payout is not.
     expect(scoreSketch(ring('BR'), ring('AU'), 100)).toBeLessThanOrEqual(15)
     expect(scoreSketch(ring('EG'), ring('CL'), 100)).toBeLessThanOrEqual(10)
+  })
+})
+
+// Reveal pacing: the outline modes' preview sweep and clock-synced draw.
+
+const perimeter = (points: OutlinePoint[]): number => {
+  let total = 0
+  for (let index = 0; index < points.length; index++) {
+    const [x1, y1] = points[index]
+    const [x2, y2] = points[(index + 1) % points.length]
+    total += Math.hypot(x2 - x1, y2 - y1)
+  }
+  return total
+}
+
+const ringSpan = (points: OutlinePoint[]): number => {
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const [x, y] of points) {
+    minX = Math.min(minX, x)
+    minY = Math.min(minY, y)
+    maxX = Math.max(maxX, x)
+    maxY = Math.max(maxY, y)
+  }
+  return Math.max(maxX - minX, maxY - minY)
+}
+
+describe('previewSweepSeconds', () => {
+  it('stays within its bounds for any geometry', () => {
+    expect(previewSweepSeconds(0, 0)).toBeGreaterThanOrEqual(0.7)
+    expect(previewSweepSeconds(1, 1000)).toBeGreaterThanOrEqual(0.7)
+    expect(previewSweepSeconds(1_000_000, 1)).toBeLessThanOrEqual(2.4)
+  })
+
+  it('gives an intricate coastline a longer sweep than a compact one', () => {
+    const norway = ring('NO')
+    const egypt = ring('EG')
+    const intricate = previewSweepSeconds(perimeter(norway), ringSpan(norway))
+    const compact = previewSweepSeconds(perimeter(egypt), ringSpan(egypt))
+    expect(intricate).toBeGreaterThan(compact)
+  })
+})
+
+describe('drawnFraction', () => {
+  it('starts at zero where the preview handed over', () => {
+    expect(drawnFraction(26, 30, 26)).toBe(0)
+  })
+
+  it('completes exactly when the study beat begins, for any hand-over point', () => {
+    for (const drawStart of [30, 26, 20]) {
+      const studyBeat = 30 * (1 - DRAW_COMPLETE_AT)
+      expect(drawnFraction(studyBeat, 30, drawStart)).toBe(1)
+      expect(drawnFraction(0, 30, drawStart)).toBe(1)
+    }
+  })
+
+  it('grows monotonically as the clock runs down', () => {
+    let previous = -1
+    for (let secondsLeft = 26; secondsLeft >= 0; secondsLeft--) {
+      const drawn = drawnFraction(secondsLeft, 30, 26)
+      expect(drawn).toBeGreaterThanOrEqual(previous)
+      previous = drawn
+    }
   })
 })

--- a/lib/outline.ts
+++ b/lib/outline.ts
@@ -9,15 +9,34 @@ export type OutlinePoint = [number, number]
 export const countryPathData = (isoCode: ISOCountryCode): string | undefined =>
   document.querySelector(`.game-map path#${isoCode}`)?.getAttribute('d') ?? undefined
 
+/** Stroke width as a share of the frame — the classic hairline at stage size. */
+const STROKE_WIDTH_RATIO = 0.0045
+
 /**
  * A country's MAINLAND ring as standalone path data, framed in its own
  * padded viewBox. Dash-reveals need one closed ring — the raw map path often
  * carries island subpaths that would smear the reveal into scattered slivers.
+ *
+ * Geometry comes from the HD tier (the same lazy chunk GameMap zooms into):
+ * the outline stage blows a single country up to near-full-screen, where the
+ * base tier's world-zoom simplification reads as jagged. Scraping the DOM is
+ * only the fallback — the DOM path holds whatever tier the last camera
+ * position happened to apply, so it isn't even deterministic.
+ *
+ * `strokeWidth` is in user units, scaled to the frame. The tempting
+ * alternative — a fixed width with vector-effect: non-scaling-stroke — is a
+ * trap for dash-reveals: per SVG2 (and Chromium) it moves stroke-dasharray
+ * and stroke-dashoffset into SCREEN space while getTotalLength stays in user
+ * units, shattering the reveal into repeating fragments. Everything must
+ * live in the country's own units.
  */
-export const mainlandOutline = (
+export const mainlandOutline = async (
   isoCode: ISOCountryCode
-): { d: string; viewBox: string } | undefined => {
-  const pathData = countryPathData(isoCode)
+): Promise<{ d: string; viewBox: string; span: number; strokeWidth: number } | undefined> => {
+  const hd = await import('~~/data/map-hd.gen')
+    .then(module => module.MAP_PATHS_HD as Partial<Record<ISOCountryCode, string>>)
+    .catch(() => undefined)
+  const pathData = hd?.[isoCode] ?? countryPathData(isoCode)
   if (!pathData) return undefined
   const ring = largestRing(pathData)
   if (!ring || ring.length < 3) return undefined
@@ -33,11 +52,50 @@ export const mainlandOutline = (
     maxY = Math.max(maxY, y)
   }
 
-  const pad = Math.max(maxX - minX, maxY - minY) * 0.12
+  const span = Math.max(maxX - minX, maxY - minY)
+  const pad = span * 0.12
   return {
     d: `M ${ring.map(([x, y]) => `${x},${y}`).join(' L ')} Z`,
     viewBox: `${minX - pad} ${minY - pad} ${maxX - minX + pad * 2} ${maxY - minY + pad * 2}`,
+    span,
+    strokeWidth: span * STROKE_WIDTH_RATIO,
   }
+}
+
+// --- Dash-reveal pacing --------------------------------------------------------
+// Every duration here derives from the border's measured geometry, so the
+// animation is relative to the country's size: the draw rate is proportional
+// to its perimeter (it must cover `length` in a fixed clock share), and the
+// preview sweep scales with intricacy (perimeter relative to frame).
+
+/** The whole border lands with this fraction of the clock spent, leaving a
+ *  beat to study the complete shape before time runs out. */
+export const DRAW_COMPLETE_AT = 0.85
+
+/**
+ * Seconds for the preview's sweep-away, scaled to the border's intricacy —
+ * its length relative to the span of its frame. A compact shape wipes in
+ * under a second; a fjord-riddled coastline visibly unwinds.
+ */
+export const previewSweepSeconds = (length: number, span: number): number => {
+  if (length <= 0 || span <= 0) return 0.7
+  return Math.min(2.4, Math.max(0.7, 0.4 + (length / span) * 0.09))
+}
+
+/**
+ * Fraction of the border drawn at `secondsLeft`. The draw picks up where the
+ * preview handed over (`drawStartSecondsLeft`) and maps that remaining window
+ * onto the clock so every country — however long its border — completes at
+ * DRAW_COMPLETE_AT of the round.
+ */
+export const drawnFraction = (
+  secondsLeft: number,
+  totalSeconds: number,
+  drawStartSecondsLeft: number
+): number => {
+  const drawEndsAt = totalSeconds * (1 - DRAW_COMPLETE_AT)
+  const window = Math.max(1, drawStartSecondsLeft - drawEndsAt)
+  return Math.min(1, Math.max(0, (drawStartSecondsLeft - secondsLeft) / window))
 }
 
 /**

--- a/lib/useOutlineReveal.ts
+++ b/lib/useOutlineReveal.ts
@@ -1,0 +1,121 @@
+import { nextTick, ref } from 'vue'
+import { prefersReducedMotion } from '~~/lib/motion'
+import { drawnFraction, mainlandOutline, previewSweepSeconds } from '~~/lib/outline'
+import type { ISOCountryCode } from '~~/types/geography.types'
+
+/** How long the whole border holds on screen before sweeping away. */
+const PREVIEW_HOLD_MS = 1600
+
+/**
+ * The shared choreography of the outline-guessing modes (group Silhouette and
+ * the individual outline-reveal gate): the full border flashes as a preview,
+ * sweeps itself away, then draws back in against the round clock.
+ *
+ * All dash math runs in the path's REAL length units from getTotalLength(),
+ * and the path must render in those same units (see mainlandOutline on why
+ * non-scaling-stroke would shatter the dashes). The pathLength="1" trick is
+ * a trap too: values written with px units (as animation libraries do)
+ * bypass pathLength normalization in Chrome, leaving a frozen confetti of
+ * 1px dashes. Real units + CSS transitions are boringly reliable, and they
+ * make the pacing size-relative for free — covering the measured perimeter
+ * in a fixed clock share means a longer border draws proportionally faster,
+ * and every country completes on the same beat.
+ */
+export const useOutlineReveal = () => {
+  /** The country's mainland ring, framed in its own padded viewBox. */
+  const outline = ref<{ d: string; viewBox: string; span: number; strokeWidth: number }>()
+  const outlinePath = ref<SVGPathElement>()
+
+  type Phase = 'idle' | 'preview' | 'sweep' | 'drawing'
+  let phase: Phase = 'idle'
+  let length = 0
+  let totalSeconds = 0
+  let lastSecondsLeft = Infinity
+  let drawStartSecondsLeft = 0
+  let prepared: Promise<void> = Promise.resolve()
+  // Bumped by reset so a begin still awaiting geometry can't arm a stale round.
+  let generation = 0
+  let previewTimer: ReturnType<typeof setTimeout> | undefined
+  let sweepTimer: ReturnType<typeof setTimeout> | undefined
+
+  const prepareOutline = (isoCode: ISOCountryCode) => {
+    prepared = mainlandOutline(isoCode).then(frame => {
+      outline.value = frame
+    })
+  }
+
+  /**
+   * Kick off preview → sweep → draw. Awaits the geometry (the HD chunk may
+   * still be in flight) and its render, so callers just fire it — but they
+   * must not gate their own clock on it: a missing outline no-ops here.
+   * Under reduced motion the full outline simply stays put for the round.
+   */
+  const beginOutlineReveal = async (durationSeconds: number) => {
+    const armed = generation
+    await prepared
+    await nextTick()
+    const path = outlinePath.value
+    const frame = outline.value
+    length = path?.getTotalLength() ?? 0
+    if (armed !== generation || !path || !frame || !length) return
+
+    totalSeconds = durationSeconds
+    // Ticks may already be running if the geometry arrived late.
+    lastSecondsLeft = Math.min(lastSecondsLeft, durationSeconds)
+    phase = 'preview'
+    path.style.strokeDasharray = `${length}`
+    path.style.transition = 'none'
+    path.style.strokeDashoffset = '0'
+    if (prefersReducedMotion()) return
+
+    previewTimer = setTimeout(() => {
+      // The sweep-away un-draws the border at a pace set by its intricacy —
+      // the transition lands in the same style flush as the offset change,
+      // and per spec the after-change style's transition applies.
+      const sweep = previewSweepSeconds(length, frame.span)
+      phase = 'sweep'
+      path.style.transition = `stroke-dashoffset ${sweep}s ease-in`
+      path.style.strokeDashoffset = `${length}`
+
+      sweepTimer = setTimeout(() => {
+        // Ticks land once per second; a matching linear transition chains
+        // them into one continuous, ever-growing stroke.
+        phase = 'drawing'
+        drawStartSecondsLeft = lastSecondsLeft
+        path.style.transition = 'stroke-dashoffset 1s linear'
+      }, sweep * 1000)
+    }, PREVIEW_HOLD_MS)
+  }
+
+  /** Countdown hook: advances the border by this tick's share of the clock. */
+  const tickOutlineReveal = (secondsLeft: number) => {
+    lastSecondsLeft = secondsLeft
+    const path = outlinePath.value
+    if (phase !== 'drawing' || !path || !length) return
+    const drawn = drawnFraction(secondsLeft, totalSeconds, drawStartSecondsLeft)
+    path.style.strokeDashoffset = `${length * (1 - drawn)}`
+  }
+
+  /** Clear timers and state — round cleanup and back-to-back gate resets. */
+  const resetOutlineReveal = () => {
+    if (previewTimer) clearTimeout(previewTimer)
+    if (sweepTimer) clearTimeout(sweepTimer)
+    previewTimer = undefined
+    sweepTimer = undefined
+    generation++
+    phase = 'idle'
+    length = 0
+    lastSecondsLeft = Infinity
+    prepared = Promise.resolve()
+    outline.value = undefined
+  }
+
+  return {
+    outline,
+    outlinePath,
+    prepareOutline,
+    beginOutlineReveal,
+    tickOutlineReveal,
+    resetOutlineReveal,
+  }
+}


### PR DESCRIPTION
Consolidates the outline-guessing animation logic (preview flash → sweep-away → clock-synced draw) into a shared `useOutlineReveal` composable, eliminating duplication between ViewSilhouette and ViewIndividualChallenge.

**Key changes:**
- New `useOutlineReveal()` composable encapsulates the full reveal choreography with phase management, timing, and state cleanup
- Refactored `mainlandOutline()` to async, now fetches HD geometry and returns frame span + computed stroke width for size-relative rendering
- Added `previewSweepSeconds()` and `drawnFraction()` utilities to scale animation timing by border intricacy and perimeter
- Removed `vector-effect: non-scaling-stroke` from SVG paths — stroke width now arrives as a user-unit attribute to keep dash arrays and offsets in consistent units (fixes dash-reveal fragmentation in Chrome)
- Updated both silhouette and outline-reveal gates to use the composable, reducing component logic by ~40 lines each
- Updated challenge description text to reflect the new preview flash behavior

**Implementation details:**
- All dash math runs in path's real length units from `getTotalLength()` to ensure reliable, size-relative animation
- Generation counter prevents stale rounds from arming when geometry arrives late
- Clock runs independently of outline resolution — gates never hang waiting for geometry
- Stroke width scales proportionally to frame span (0.45% ratio) for consistent visual weight across countries

https://claude.ai/code/session_0113XEBUaQM6f7JZiT4qodVi