### PR TITLE
Harden challengeOverrides intake validators

### DIFF
--- a/lib/challenge-groups.test.ts
+++ b/lib/challenge-groups.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { getGroupChallenge } from '~~/lib/challenges'
+import { isValidGameConfiguration } from '~~/types/game.types'
 import {
   autoEnabledKinds,
   CHALLENGE_GROUP_ACCESSORS,
@@ -143,5 +144,40 @@ describe('isValidChallengeOverrides', () => {
     expect(isValidChallengeOverrides({ conflicts: 'off' })).toBe(false)
     expect(isValidChallengeOverrides(['conflicts'])).toBe(false)
     expect(isValidChallengeOverrides(undefined)).toBe(false)
+  })
+
+  it('rejects prototype-chain keys that are not real groups', () => {
+    expect(isValidChallengeOverrides({ toString: true })).toBe(false)
+    expect(isValidChallengeOverrides({ constructor: false })).toBe(false)
+    expect(isValidChallengeOverrides({ hasOwnProperty: true })).toBe(false)
+  })
+})
+
+describe('isValidGameConfiguration', () => {
+  const valid = {
+    difficulty: 'normal',
+    variant: 'world',
+    length: 'medium',
+    liveGuesses: true,
+    challengeOverrides: { conflicts: false },
+  }
+
+  it('accepts a well-formed configuration', () => {
+    expect(isValidGameConfiguration(valid)).toBe(true)
+  })
+
+  it('rejects unknown difficulty and length values, not just missing keys', () => {
+    expect(isValidGameConfiguration({ ...valid, difficulty: 'nightmare' })).toBe(false)
+    expect(isValidGameConfiguration({ ...valid, length: 'marathon' })).toBe(false)
+    // FormData strings that never got coerced must not slip through either.
+    expect(isValidGameConfiguration({ ...valid, liveGuesses: 'on' })).toBe(false)
+  })
+
+  it('rejects missing or malformed overrides', () => {
+    const { challengeOverrides: _dropped, ...withoutOverrides } = valid
+    expect(isValidGameConfiguration(withoutOverrides)).toBe(false)
+    expect(isValidGameConfiguration({ ...valid, challengeOverrides: { toString: true } })).toBe(
+      false
+    )
   })
 })

--- a/types/challenges/challenge-groups.type.ts
+++ b/types/challenges/challenge-groups.type.ts
@@ -27,7 +27,9 @@ export type ChallengeGroupId = keyof typeof CHALLENGE_GROUPS
 export type ChallengeOverrides = Partial<Record<ChallengeGroupId, boolean>>
 
 export const isValidChallengeGroupId = (value: unknown): value is ChallengeGroupId =>
-  typeof value === 'string' && value in CHALLENGE_GROUPS
+  // Object.hasOwn, not `in` — `in` walks the prototype chain, so keys like
+  // 'toString' would validate and be stored into game state.
+  typeof value === 'string' && Object.hasOwn(CHALLENGE_GROUPS, value)
 
 export const isValidChallengeOverrides = (value: unknown): value is ChallengeOverrides =>
   !!value &&

--- a/types/game.types.ts
+++ b/types/game.types.ts
@@ -93,15 +93,17 @@ export interface GameConfiguration {
 export const isValidGameConfiguration = (data: unknown): data is GameConfiguration => {
   if (!data) return false
   if (typeof data !== 'object') return false
-  if (![`difficulty`, 'length', 'variant', 'liveGuesses'].every(key => Reflect.has(data, key)))
-    return false
-  if (!isValidGameVariant((data as GameConfiguration).variant)) return false
+  const configuration = data as GameConfiguration
+  // Values, not just key presence — game.difficulty indexes
+  // DIFFICULTY_CONFIGURATION and drives every challenge gate, so an unknown
+  // difficulty from a crafted payload would crash the dealer server-side.
+  if (!isValidGameVariant(configuration.variant)) return false
+  if (!gameDifficulties.includes(configuration.difficulty)) return false
+  if (!gameLengths.includes(configuration.length)) return false
   // FormData hands every field over as a string; the form must coerce first.
-  if (typeof (data as GameConfiguration).liveGuesses !== 'boolean') return false
+  if (typeof configuration.liveGuesses !== 'boolean') return false
 
-  if (!isValidChallengeOverrides((data as GameConfiguration).challengeOverrides)) return false
-
-  return true
+  return isValidChallengeOverrides(configuration.challengeOverrides)
 }
 
 export const gameLengths = ['short', 'medium', 'long'] as const


### PR DESCRIPTION
Audit found the tri-state gate logic sound (core kinds keep the game
playable whatever the toggles say), but two holes in the payload
validators:

- isValidChallengeGroupId used `in`, which walks the prototype chain,
  so keys like 'toString' validated and were stored into game state.
  Now checks own properties only.
- isValidGameConfiguration checked that difficulty/length keys existed
  but never their values, so a crafted payload could put an unknown
  difficulty into game state — crashing DIFFICULTY_CONFIGURATION
  lookups and skewing every difficulty-keyed challenge gate. Values
  now validate against the canonical unions.

Regression tests cover both.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TeGzD98GqLMvD5XJwhSsdC